### PR TITLE
Add benchmark for sub_assign

### DIFF
--- a/curve-benches/src/macros/ec.rs
+++ b/curve-benches/src/macros/ec.rs
@@ -42,6 +42,24 @@ macro_rules! ec_bench {
             });
         }
 
+        fn sub_assign(b: &mut $crate::bencher::Bencher) {
+            const SAMPLES: usize = 1000;
+
+            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+            let v: Vec<($projective, $projective)> = (0..SAMPLES)
+                .map(|_| (<$projective>::rand(&mut rng), <$projective>::rand(&mut rng)))
+                .collect();
+
+            let mut count = 0;
+            b.iter(|| {
+                let mut tmp = v[count].0;
+                n_fold!(tmp, v, sub_assign, count);
+                count = (count + 1) % SAMPLES;
+                tmp
+            });
+        }
+
         fn double(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
@@ -199,6 +217,7 @@ macro_rules! ec_bench {
             rand,
             mul_assign,
             add_assign,
+            sub_assign,
             add_assign_mixed,
             double,
             ser,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This adds a benchmark for `sub_assign` to the relevant macro.

For bls12_381, we see the following speed difference with no asm on snarky:
```
test bls12_381::g1::add_assign        ... bench:       1,004 ns/iter (+/- 30)
test bls12_381::g1::sub_assign        ... bench:       1,027 ns/iter (+/- 29)
```
which seems roughly right (a difference of one field negation)
---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md` - N/A
- [x] Re-reviewed `Files changed` in the Github PR explorer
