### PR TITLE
Replace `rand` with `ark_std::rand`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,15 @@
         `ark-mnt4-298`,
         `ark-mnt6-298`,
         `ark-mnt4-753`,
-        `ark-mnt6-753`
-- #7 Add benchmarks for Edwards curves
+        `ark-mnt6-753`.
+- #7 Add benchmarks for Edwards curves.
 - #19 Change field constants to be provided as normal strings, instead of in montgomery form.
 
+### Improvements
+- #42 Remove the dependency of `rand_xorshift`.
+
 ### Bug fixes
-- #28 fix broken documentation links
+- #28 Fix broken documentation links.
 - #38 Compile with `panic='abort'` in release mode, for safety of the library across FFI boundaries.
 
 ## v0.1.0

--- a/bls12_377/Cargo.toml
+++ b/bls12_377/Cargo.toml
@@ -23,8 +23,6 @@ ark-relations = { git = "https://github.com/arkworks-rs/snark", default-features
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-curve-constraint-tests = { path = "../curve-constraint-tests", default-features = false }
-rand = { version = "0.7", default-features = false }
-rand_xorshift = "0.2"
 
 [features]
 default = [ "curve" ]

--- a/bls12_377/src/curves/tests.rs
+++ b/bls12_377/src/curves/tests.rs
@@ -8,7 +8,7 @@ use ark_std::test_rng;
 
 use ark_ec::{models::SWModelParameters, AffineCurve, PairingEngine, ProjectiveCurve};
 use core::ops::{AddAssign, MulAssign};
-use rand::Rng;
+use ark_std::rand::Rng;
 
 use crate::{g1, g2, Bls12_377, Fq, Fq12, Fq2, Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 

--- a/bls12_377/src/curves/tests.rs
+++ b/bls12_377/src/curves/tests.rs
@@ -7,8 +7,8 @@ use ark_serialize::CanonicalSerialize;
 use ark_std::test_rng;
 
 use ark_ec::{models::SWModelParameters, AffineCurve, PairingEngine, ProjectiveCurve};
-use core::ops::{AddAssign, MulAssign};
 use ark_std::rand::Rng;
+use core::ops::{AddAssign, MulAssign};
 
 use crate::{g1, g2, Bls12_377, Fq, Fq12, Fq2, Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 

--- a/bls12_377/src/fields/tests.rs
+++ b/bls12_377/src/fields/tests.rs
@@ -7,12 +7,12 @@ use ark_ff::{
     One, UniformRand, Zero,
 };
 use ark_serialize::{buffer_bit_byte_size, CanonicalSerialize};
+use ark_std::rand::Rng;
 use ark_std::test_rng;
 use core::{
     cmp::Ordering,
     ops::{AddAssign, MulAssign, SubAssign},
 };
-use ark_std::rand::Rng;
 
 use crate::{Fq, Fq12, Fq2, Fq2Parameters, Fq6, Fq6Parameters, FqParameters, Fr};
 

--- a/bls12_377/src/fields/tests.rs
+++ b/bls12_377/src/fields/tests.rs
@@ -12,8 +12,7 @@ use core::{
     cmp::Ordering,
     ops::{AddAssign, MulAssign, SubAssign},
 };
-use rand::{Rng, SeedableRng};
-use rand_xorshift::XorShiftRng;
+use ark_std::rand::Rng;
 
 use crate::{Fq, Fq12, Fq2, Fq2Parameters, Fq6, Fq6Parameters, FqParameters, Fr};
 
@@ -135,7 +134,7 @@ fn test_fq_repr_num_bits() {
 fn test_fq_add_assign() {
     // Test associativity
 
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         // Generate a, b, c and ensure (a + b) + c == a + (b + c).
@@ -157,7 +156,7 @@ fn test_fq_add_assign() {
 
 #[test]
 fn test_fq_sub_assign() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         // Ensure that (a - b) + (b - a) = 0.
@@ -177,7 +176,7 @@ fn test_fq_sub_assign() {
 
 #[test]
 fn test_fq_mul_assign() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000000 {
         // Ensure that (a * b) * c = a * (b * c)
@@ -222,7 +221,7 @@ fn test_fq_mul_assign() {
 
 #[test]
 fn test_fq_squaring() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000000 {
         // Ensure that (a * a) = a^2
@@ -242,7 +241,7 @@ fn test_fq_squaring() {
 fn test_fq_inverse() {
     assert!(Fq::zero().inverse().is_none());
 
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     let one = Fq::one();
 
@@ -257,7 +256,7 @@ fn test_fq_inverse() {
 
 #[test]
 fn test_fq_double_in_place() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         // Ensure doubling a is equivalent to adding a to itself.
@@ -277,7 +276,7 @@ fn test_fq_negate() {
         assert!(a.is_zero());
     }
 
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         // Ensure (a - (-a)) = 0.
@@ -291,7 +290,7 @@ fn test_fq_negate() {
 
 #[test]
 fn test_fq_pow() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for i in 0..1000 {
         // Exponentiate by various small numbers and ensure it consists with repeated
@@ -315,7 +314,7 @@ fn test_fq_pow() {
 
 #[test]
 fn test_fq_sqrt() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     assert_eq!(Fq::zero().sqrt().unwrap(), Fq::zero());
 
@@ -438,7 +437,7 @@ fn test_fq2_legendre() {
 
 #[test]
 fn test_fq2_mul_nonresidue() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     let nqr = Fq2::new(Fq::zero(), Fq::one());
 
@@ -458,7 +457,7 @@ fn test_fq2_mul_nonresidue() {
 
 #[test]
 fn test_fq6_mul_by_1() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let c1 = Fq2::rand(&mut rng);
@@ -474,7 +473,7 @@ fn test_fq6_mul_by_1() {
 
 #[test]
 fn test_fq6_mul_by_01() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let c0 = Fq2::rand(&mut rng);
@@ -491,7 +490,7 @@ fn test_fq6_mul_by_01() {
 
 #[test]
 fn test_fq12_mul_by_014() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let c0 = Fq2::rand(&mut rng);
@@ -512,7 +511,7 @@ fn test_fq12_mul_by_014() {
 
 #[test]
 fn test_fq12_mul_by_034() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = test_rng();
 
     for _ in 0..1000 {
         let c0 = Fq2::rand(&mut rng);

--- a/bls12_381/Cargo.toml
+++ b/bls12_381/Cargo.toml
@@ -20,8 +20,6 @@ ark-std = { git = "https://github.com/arkworks-rs/utils", default-features = fal
 [dev-dependencies]
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
-rand = { version = "0.7", default-features = false }
-rand_xorshift = "0.2"
 
 [features]
 default = [ "curve" ]

--- a/bls12_381/src/curves/tests.rs
+++ b/bls12_381/src/curves/tests.rs
@@ -5,9 +5,9 @@ use ark_ff::{
     One, Zero,
 };
 use ark_serialize::CanonicalSerialize;
+use ark_std::rand::Rng;
 use ark_std::test_rng;
 use core::ops::{AddAssign, MulAssign};
-use ark_std::rand::Rng;
 
 use crate::{g1, g2, Bls12_381, Fq, Fq12, Fq2, Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_algebra_test_templates::{curves::*, groups::*};

--- a/bls12_381/src/curves/tests.rs
+++ b/bls12_381/src/curves/tests.rs
@@ -7,7 +7,7 @@ use ark_ff::{
 use ark_serialize::CanonicalSerialize;
 use ark_std::test_rng;
 use core::ops::{AddAssign, MulAssign};
-use rand::Rng;
+use ark_std::rand::Rng;
 
 use crate::{g1, g2, Bls12_381, Fq, Fq12, Fq2, Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 use ark_algebra_test_templates::{curves::*, groups::*};

--- a/bls12_381/src/fields/tests.rs
+++ b/bls12_381/src/fields/tests.rs
@@ -10,8 +10,6 @@ use core::{
     cmp::Ordering,
     ops::{AddAssign, MulAssign, SubAssign},
 };
-use rand::SeedableRng;
-use rand_xorshift::XorShiftRng;
 
 use crate::{Fq, Fq12, Fq12Parameters, Fq2, Fq2Parameters, Fq6, Fq6Parameters, FqParameters, Fr};
 use ark_algebra_test_templates::fields::*;
@@ -20,7 +18,7 @@ pub(crate) const ITERATIONS: usize = 5;
 
 #[test]
 fn test_fr() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
     for _ in 0..ITERATIONS {
         let a: Fr = UniformRand::rand(&mut rng);
         let b: Fr = UniformRand::rand(&mut rng);
@@ -32,7 +30,7 @@ fn test_fr() {
 
 #[test]
 fn test_fq() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
     for _ in 0..ITERATIONS {
         let a: Fq = UniformRand::rand(&mut rng);
         let b: Fq = UniformRand::rand(&mut rng);
@@ -44,7 +42,7 @@ fn test_fq() {
 
 #[test]
 fn test_fq2() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
     for _ in 0..ITERATIONS {
         let a: Fq2 = UniformRand::rand(&mut rng);
         let b: Fq2 = UniformRand::rand(&mut rng);
@@ -56,7 +54,7 @@ fn test_fq2() {
 
 #[test]
 fn test_fq6() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
     for _ in 0..ITERATIONS {
         let g: Fq6 = UniformRand::rand(&mut rng);
         let h: Fq6 = UniformRand::rand(&mut rng);
@@ -67,7 +65,7 @@ fn test_fq6() {
 
 #[test]
 fn test_fq12() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
     for _ in 0..ITERATIONS {
         let g: Fq12 = UniformRand::rand(&mut rng);
         let h: Fq12 = UniformRand::rand(&mut rng);
@@ -1007,7 +1005,7 @@ fn test_fq_repr_num_bits() {
 
 #[test]
 fn test_fq_repr_sub_noborrow() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     let mut t = BigInteger384([
         0x827a4a08041ebd9,
@@ -1094,7 +1092,7 @@ fn test_fq_repr_sub_noborrow() {
 
 #[test]
 fn test_fq_repr_add_nocarry() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     let mut t = BigInteger384([
         0x827a4a08041ebd9,
@@ -1282,7 +1280,7 @@ fn test_fq_add_assign() {
 
     // Test associativity
 
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..1000 {
         // Generate a, b, c and ensure (a + b) + c == a + (b + c).
@@ -1390,7 +1388,7 @@ fn test_fq_sub_assign() {
         );
     }
 
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..1000 {
         // Ensure that (a - b) + (b - a) = 0.
@@ -1437,7 +1435,7 @@ fn test_fq_mul_assign() {
         ]))
     );
 
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..1000000 {
         // Ensure that (a * b) * c = a * (b * c)
@@ -1503,7 +1501,7 @@ fn test_fq_squaring() {
         ]))
     );
 
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..1000000 {
         // Ensure that (a * a) = a^2
@@ -1523,7 +1521,7 @@ fn test_fq_squaring() {
 fn test_fq_inverse() {
     assert!(Fq::zero().inverse().is_none());
 
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     let one = Fq::one();
 
@@ -1538,7 +1536,7 @@ fn test_fq_inverse() {
 
 #[test]
 fn test_fq_double_in_place() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..1000 {
         // Ensure doubling a is equivalent to adding a to itself.
@@ -1558,7 +1556,7 @@ fn test_fq_negate() {
         assert!(a.is_zero());
     }
 
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..1000 {
         // Ensure (a - (-a)) = 0.
@@ -1572,7 +1570,7 @@ fn test_fq_negate() {
 
 #[test]
 fn test_fq_pow() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for i in 0..1000 {
         // Exponentiate by various small numbers and ensure it consists with repeated
@@ -1596,7 +1594,7 @@ fn test_fq_pow() {
 
 #[test]
 fn test_fq_sqrt() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     assert_eq!(Fq::zero().sqrt().unwrap(), Fq::zero());
 
@@ -2237,7 +2235,7 @@ fn test_fq2_legendre() {
 
 #[test]
 fn test_fq2_mul_nonresidue() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     let nqr = Fq2::new(Fq::one(), Fq::one());
 
@@ -2253,7 +2251,7 @@ fn test_fq2_mul_nonresidue() {
 
 #[test]
 fn test_fq6_mul_nonresidue() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     let nqr = Fq6::new(Fq2::zero(), Fq2::one(), Fq2::zero());
 
@@ -2269,7 +2267,7 @@ fn test_fq6_mul_nonresidue() {
 
 #[test]
 fn test_fq6_mul_by_1() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..1000 {
         let c1 = Fq2::rand(&mut rng);
@@ -2285,7 +2283,7 @@ fn test_fq6_mul_by_1() {
 
 #[test]
 fn test_fq6_mul_by_01() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..1000 {
         let c0 = Fq2::rand(&mut rng);
@@ -2302,7 +2300,7 @@ fn test_fq6_mul_by_01() {
 
 #[test]
 fn test_fq12_mul_by_014() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..1000 {
         let c0 = Fq2::rand(&mut rng);

--- a/bn254/Cargo.toml
+++ b/bn254/Cargo.toml
@@ -20,8 +20,6 @@ ark-std = { git = "https://github.com/arkworks-rs/utils", default-features = fal
 [dev-dependencies]
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
-rand = { version = "0.7", default-features = false }
-rand_xorshift = "0.2"
 
 [features]
 default = [ "curve" ]

--- a/bn254/src/curves/tests.rs
+++ b/bn254/src/curves/tests.rs
@@ -5,9 +5,9 @@ use ark_ff::{
     One, Zero,
 };
 use ark_serialize::CanonicalSerialize;
+use ark_std::rand::Rng;
 use ark_std::test_rng;
 use core::ops::{AddAssign, MulAssign};
-use ark_std::rand::Rng;
 
 use crate::{g1, g2, Bn254, Fq, Fq12, Fq2, Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 

--- a/bn254/src/curves/tests.rs
+++ b/bn254/src/curves/tests.rs
@@ -7,7 +7,7 @@ use ark_ff::{
 use ark_serialize::CanonicalSerialize;
 use ark_std::test_rng;
 use core::ops::{AddAssign, MulAssign};
-use rand::Rng;
+use ark_std::rand::Rng;
 
 use crate::{g1, g2, Bn254, Fq, Fq12, Fq2, Fr, G1Affine, G1Projective, G2Affine, G2Projective};
 

--- a/bn254/src/fields/tests.rs
+++ b/bn254/src/fields/tests.rs
@@ -12,8 +12,7 @@ use core::{
     cmp::Ordering,
     ops::{AddAssign, MulAssign, SubAssign},
 };
-use rand::{Rng, SeedableRng};
-use rand_xorshift::XorShiftRng;
+use ark_std::rand::Rng;
 
 use crate::{Fq, Fq12, Fq2, Fq6, Fq6Parameters, FqParameters, Fr};
 use ark_algebra_test_templates::fields::*;
@@ -130,7 +129,7 @@ fn test_fq_repr_num_bits() {
 fn test_fq_add_assign() {
     // Test associativity
 
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..1000 {
         // Generate a, b, c and ensure (a + b) + c == a + (b + c).
@@ -152,7 +151,7 @@ fn test_fq_add_assign() {
 
 #[test]
 fn test_fq_sub_assign() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..1000 {
         // Ensure that (a - b) + (b - a) = 0.
@@ -172,7 +171,7 @@ fn test_fq_sub_assign() {
 
 #[test]
 fn test_fq_mul_assign() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..1000000 {
         // Ensure that (a * b) * c = a * (b * c)
@@ -217,7 +216,7 @@ fn test_fq_mul_assign() {
 
 #[test]
 fn test_fq_squaring() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..1000000 {
         // Ensure that (a * a) = a^2
@@ -237,7 +236,7 @@ fn test_fq_squaring() {
 fn test_fq_inverse() {
     assert!(Fq::zero().inverse().is_none());
 
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     let one = Fq::one();
 
@@ -252,7 +251,7 @@ fn test_fq_inverse() {
 
 #[test]
 fn test_fq_double_in_place() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..1000 {
         // Ensure doubling a is equivalent to adding a to itself.
@@ -272,7 +271,7 @@ fn test_fq_negate() {
         assert!(a.is_zero());
     }
 
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..1000 {
         // Ensure (a - (-a)) = 0.
@@ -286,7 +285,7 @@ fn test_fq_negate() {
 
 #[test]
 fn test_fq_pow() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for i in 0..1000 {
         // Exponentiate by various small numbers and ensure it consists with repeated
@@ -310,7 +309,7 @@ fn test_fq_pow() {
 
 #[test]
 fn test_fq_sqrt() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     assert_eq!(Fq::zero().sqrt().unwrap(), Fq::zero());
 
@@ -431,7 +430,7 @@ fn test_fq2_legendre() {
 
 #[test]
 fn test_fq6_mul_by_1() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..1000 {
         let c1 = Fq2::rand(&mut rng);
@@ -447,7 +446,7 @@ fn test_fq6_mul_by_1() {
 
 #[test]
 fn test_fq6_mul_by_01() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..1000 {
         let c0 = Fq2::rand(&mut rng);
@@ -464,7 +463,7 @@ fn test_fq6_mul_by_01() {
 
 #[test]
 fn test_fq12_mul_by_014() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..1000 {
         let c0 = Fq2::rand(&mut rng);
@@ -485,7 +484,7 @@ fn test_fq12_mul_by_014() {
 
 #[test]
 fn test_fq12_mul_by_034() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..1000 {
         let c0 = Fq2::rand(&mut rng);

--- a/bn254/src/fields/tests.rs
+++ b/bn254/src/fields/tests.rs
@@ -7,12 +7,12 @@ use ark_ff::{
     One, UniformRand, Zero,
 };
 use ark_serialize::{buffer_bit_byte_size, CanonicalSerialize};
+use ark_std::rand::Rng;
 use ark_std::test_rng;
 use core::{
     cmp::Ordering,
     ops::{AddAssign, MulAssign, SubAssign},
 };
-use ark_std::rand::Rng;
 
 use crate::{Fq, Fq12, Fq2, Fq6, Fq6Parameters, FqParameters, Fr};
 use ark_algebra_test_templates::fields::*;

--- a/bw6_761/Cargo.toml
+++ b/bw6_761/Cargo.toml
@@ -21,8 +21,6 @@ ark-bls12-377 = { path = "../bls12_377", default-features = false, features = [ 
 [dev-dependencies]
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
-rand = { version = "0.7", default-features = false }
-rand_xorshift = "0.2"
 
 [features]
 default = []

--- a/bw6_761/src/curves/tests.rs
+++ b/bw6_761/src/curves/tests.rs
@@ -1,7 +1,7 @@
 use ark_ec::{AffineCurve, PairingEngine, ProjectiveCurve};
 use ark_ff::{Field, One, PrimeField};
 use ark_std::test_rng;
-use rand::Rng;
+use ark_std::rand::Rng;
 
 use crate::*;
 

--- a/bw6_761/src/curves/tests.rs
+++ b/bw6_761/src/curves/tests.rs
@@ -1,7 +1,7 @@
 use ark_ec::{AffineCurve, PairingEngine, ProjectiveCurve};
 use ark_ff::{Field, One, PrimeField};
-use ark_std::test_rng;
 use ark_std::rand::Rng;
+use ark_std::test_rng;
 
 use crate::*;
 

--- a/bw6_761/src/fields/tests.rs
+++ b/bw6_761/src/fields/tests.rs
@@ -1,7 +1,7 @@
 use ark_ff::{Field, PrimeField};
 use ark_serialize::{buffer_bit_byte_size, CanonicalSerialize};
-use ark_std::test_rng;
 use ark_std::rand::Rng;
+use ark_std::test_rng;
 
 use crate::*;
 

--- a/bw6_761/src/fields/tests.rs
+++ b/bw6_761/src/fields/tests.rs
@@ -1,7 +1,7 @@
 use ark_ff::{Field, PrimeField};
 use ark_serialize::{buffer_bit_byte_size, CanonicalSerialize};
 use ark_std::test_rng;
-use rand::Rng;
+use ark_std::rand::Rng;
 
 use crate::*;
 

--- a/cp6_782/src/curves/tests.rs
+++ b/cp6_782/src/curves/tests.rs
@@ -1,7 +1,7 @@
 use ark_ec::{AffineCurve, PairingEngine, ProjectiveCurve};
 use ark_ff::{Field, One, PrimeField};
 use ark_std::test_rng;
-use rand::Rng;
+use ark_std::rand::Rng;
 
 use crate::*;
 

--- a/cp6_782/src/curves/tests.rs
+++ b/cp6_782/src/curves/tests.rs
@@ -1,7 +1,7 @@
 use ark_ec::{AffineCurve, PairingEngine, ProjectiveCurve};
 use ark_ff::{Field, One, PrimeField};
-use ark_std::test_rng;
 use ark_std::rand::Rng;
+use ark_std::test_rng;
 
 use crate::*;
 

--- a/cp6_782/src/fields/tests.rs
+++ b/cp6_782/src/fields/tests.rs
@@ -1,7 +1,7 @@
 use ark_ff::{Field, PrimeField};
 use ark_serialize::{buffer_bit_byte_size, CanonicalSerialize};
-use ark_std::test_rng;
 use ark_std::rand::Rng;
+use ark_std::test_rng;
 
 use crate::*;
 

--- a/cp6_782/src/fields/tests.rs
+++ b/cp6_782/src/fields/tests.rs
@@ -1,7 +1,7 @@
 use ark_ff::{Field, PrimeField};
 use ark_serialize::{buffer_bit_byte_size, CanonicalSerialize};
 use ark_std::test_rng;
-use rand::Rng;
+use ark_std::rand::Rng;
 
 use crate::*;
 

--- a/curve-benches/Cargo.toml
+++ b/curve-benches/Cargo.toml
@@ -42,9 +42,6 @@ ark-ed-on-bls12-381 = { path = "../ed_on_bls12_381" }
 ark-bw6-761 = { path = "../bw6_761" }
 ark-cp6-782 = { path = "../cp6_782" }
 
-rand = "0.7"
-rand_xorshift = { version = "0.2" }
-
 [features]
 asm = [ "ark-ff/asm"]
 parallel = [ "ark-ff/parallel",  "ark-ec/parallel", ]

--- a/curve-benches/Cargo.toml
+++ b/curve-benches/Cargo.toml
@@ -27,6 +27,7 @@ build = "build.rs"
 bencher = { version = "0.1.5" }
 
 [dev-dependencies]
+ark-std = { git = "https://github.com/arkworks-rs/utils", default-features = false }
 ark-ec = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-ff = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra", default-features = false }

--- a/curve-benches/benches/bls12_377.rs
+++ b/curve-benches/benches/bls12_377.rs
@@ -1,7 +1,5 @@
 use ark_curve_benches::*;
-use rand::SeedableRng;
-use rand_xorshift::XorShiftRng;
-use std::ops::{AddAssign, MulAssign, SubAssign};
+use ark_std::ops::{AddAssign, MulAssign, SubAssign};
 
 use ark_bls12_377::{
     fq::Fq, fq2::Fq2, fr::Fr, Bls12_377, Fq12, G1Affine, G1Projective as G1, G2Affine,

--- a/curve-benches/benches/bls12_381.rs
+++ b/curve-benches/benches/bls12_381.rs
@@ -1,7 +1,5 @@
 use ark_curve_benches::*;
-use rand::SeedableRng;
-use rand_xorshift::XorShiftRng;
-use std::ops::{AddAssign, MulAssign, SubAssign};
+use ark_std::ops::{AddAssign, MulAssign, SubAssign};
 
 use ark_bls12_381::{
     fq::Fq, fq2::Fq2, fr::Fr, Bls12_381, Fq12, G1Affine, G1Projective as G1, G2Affine,

--- a/curve-benches/benches/bn254.rs
+++ b/curve-benches/benches/bn254.rs
@@ -1,7 +1,5 @@
 use ark_curve_benches::*;
-use rand::SeedableRng;
-use rand_xorshift::XorShiftRng;
-use std::ops::{AddAssign, MulAssign, SubAssign};
+use ark_std::ops::{AddAssign, MulAssign, SubAssign};
 
 use ark_bn254::{
     fq::Fq, fq2::Fq2, fr::Fr, Bn254, Fq12, G1Affine, G1Projective as G1, G2Affine,

--- a/curve-benches/benches/bw6_761.rs
+++ b/curve-benches/benches/bw6_761.rs
@@ -1,7 +1,5 @@
 use ark_curve_benches::*;
-use rand::SeedableRng;
-use rand_xorshift::XorShiftRng;
-use std::ops::{AddAssign, MulAssign, SubAssign};
+use ark_std::ops::{AddAssign, MulAssign, SubAssign};
 
 use ark_bw6_761::{
     fq::Fq, fq3::Fq3, fr::Fr, Fq6, G1Affine, G1Projective as G1, G2Affine, G2Projective as G2,

--- a/curve-benches/benches/cp6_782.rs
+++ b/curve-benches/benches/cp6_782.rs
@@ -1,7 +1,5 @@
 use ark_curve_benches::*;
-use rand::SeedableRng;
-use rand_xorshift::XorShiftRng;
-use std::ops::{AddAssign, MulAssign, SubAssign};
+use ark_std::ops::{AddAssign, MulAssign, SubAssign};
 
 use ark_cp6_782::{
     fq::Fq, fq3::Fq3, fr::Fr, Fq6, G1Affine, G1Projective as G1, G2Affine, G2Projective as G2,

--- a/curve-benches/benches/ed_on_bls12_381.rs
+++ b/curve-benches/benches/ed_on_bls12_381.rs
@@ -1,7 +1,5 @@
 use ark_curve_benches::*;
-use rand::SeedableRng;
-use rand_xorshift::XorShiftRng;
-use std::ops::{AddAssign, MulAssign, SubAssign};
+use ark_std::ops::{AddAssign, MulAssign, SubAssign};
 
 use ark_ec::ProjectiveCurve;
 use ark_ed_on_bls12_381::{fq::Fq, fr::Fr, EdwardsAffine as GAffine, EdwardsProjective as G};

--- a/curve-benches/benches/mnt4_298.rs
+++ b/curve-benches/benches/mnt4_298.rs
@@ -1,7 +1,5 @@
 use ark_curve_benches::*;
-use rand::SeedableRng;
-use rand_xorshift::XorShiftRng;
-use std::ops::{AddAssign, MulAssign, SubAssign};
+use ark_std::ops::{AddAssign, MulAssign, SubAssign};
 
 use ark_ec::{PairingEngine, ProjectiveCurve};
 use ark_ff::{

--- a/curve-benches/benches/mnt4_753.rs
+++ b/curve-benches/benches/mnt4_753.rs
@@ -1,7 +1,5 @@
 use ark_curve_benches::*;
-use rand::SeedableRng;
-use rand_xorshift::XorShiftRng;
-use std::ops::{AddAssign, MulAssign, SubAssign};
+use ark_std::ops::{AddAssign, MulAssign, SubAssign};
 
 use ark_ec::{PairingEngine, ProjectiveCurve};
 use ark_ff::{

--- a/curve-benches/benches/mnt6_298.rs
+++ b/curve-benches/benches/mnt6_298.rs
@@ -1,7 +1,5 @@
 use ark_curve_benches::*;
-use rand::SeedableRng;
-use rand_xorshift::XorShiftRng;
-use std::ops::{AddAssign, MulAssign, SubAssign};
+use ark_std::ops::{AddAssign, MulAssign, SubAssign};
 
 use ark_ec::{PairingEngine, ProjectiveCurve};
 use ark_ff::{

--- a/curve-benches/benches/mnt6_753.rs
+++ b/curve-benches/benches/mnt6_753.rs
@@ -1,7 +1,5 @@
 use ark_curve_benches::*;
-use rand::SeedableRng;
-use rand_xorshift::XorShiftRng;
-use std::ops::{AddAssign, MulAssign, SubAssign};
+use ark_std::ops::{AddAssign, MulAssign, SubAssign};
 
 use ark_ec::{PairingEngine, ProjectiveCurve};
 use ark_ff::{

--- a/curve-benches/src/macros/ec.rs
+++ b/curve-benches/src/macros/ec.rs
@@ -2,14 +2,14 @@
 macro_rules! ec_bench {
     ($projective:ty, $affine:ty) => {
         fn rand(b: &mut $crate::bencher::Bencher) {
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
             b.iter(|| <$projective>::rand(&mut rng));
         }
 
         fn mul_assign(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let v: Vec<($projective, Fr)> = (0..SAMPLES)
                 .map(|_| (<$projective>::rand(&mut rng), Fr::rand(&mut rng)))
@@ -27,7 +27,7 @@ macro_rules! ec_bench {
         fn add_assign(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let v: Vec<($projective, $projective)> = (0..SAMPLES)
                 .map(|_| (<$projective>::rand(&mut rng), <$projective>::rand(&mut rng)))
@@ -45,7 +45,7 @@ macro_rules! ec_bench {
         fn sub_assign(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let v: Vec<($projective, $projective)> = (0..SAMPLES)
                 .map(|_| (<$projective>::rand(&mut rng), <$projective>::rand(&mut rng)))
@@ -63,7 +63,7 @@ macro_rules! ec_bench {
         fn double(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let v: Vec<$projective> = (0..SAMPLES)
                 .map(|_| <$projective>::rand(&mut rng))
@@ -81,7 +81,7 @@ macro_rules! ec_bench {
         fn add_assign_mixed(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let v: Vec<($projective, $affine)> = (0..SAMPLES)
                 .map(|_| {
@@ -106,7 +106,7 @@ macro_rules! ec_bench {
             use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let mut num_bytes = 0;
             let tmp = <$projective>::rand(&mut rng).into_affine();
@@ -132,7 +132,7 @@ macro_rules! ec_bench {
             use ark_serialize::CanonicalSerialize;
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let mut v: Vec<_> = (0..SAMPLES)
                 .map(|_| <$projective>::rand(&mut rng))
@@ -154,7 +154,7 @@ macro_rules! ec_bench {
             use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let mut num_bytes = 0;
             let tmp = <$projective>::rand(&mut rng).into_affine();
@@ -179,7 +179,7 @@ macro_rules! ec_bench {
             use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let mut v: Vec<_> = (0..SAMPLES)
                 .map(|_| <$projective>::rand(&mut rng))
@@ -200,7 +200,7 @@ macro_rules! ec_bench {
             use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
             const SAMPLES: usize = 131072;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let g = <$projective>::rand(&mut rng).into_affine();
             let v: Vec<_> = (0..SAMPLES).map(|_| g).collect();

--- a/curve-benches/src/macros/field.rs
+++ b/curve-benches/src/macros/field.rs
@@ -92,7 +92,7 @@ macro_rules! field_common {
         fn add_assign(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let v: Vec<_> = (0..SAMPLES)
                 .map(|_| ($f::rand(&mut rng), $f::rand(&mut rng)))
@@ -110,7 +110,7 @@ macro_rules! field_common {
         fn sub_assign(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let v: Vec<_> = (0..SAMPLES)
                 .map(|_| ($f::rand(&mut rng), $f::rand(&mut rng)))
@@ -128,7 +128,7 @@ macro_rules! field_common {
         fn double(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let v: Vec<$f_type> = (0..SAMPLES).map(|_| $f::rand(&mut rng)).collect();
 
@@ -144,7 +144,7 @@ macro_rules! field_common {
         fn negate(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let v: Vec<$f_type> = (0..SAMPLES).map(|_| $f::rand(&mut rng)).collect();
 
@@ -160,7 +160,7 @@ macro_rules! field_common {
         fn mul_assign(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let v: Vec<_> = (0..SAMPLES)
                 .map(|_| ($f::rand(&mut rng), $f::rand(&mut rng)))
@@ -178,7 +178,7 @@ macro_rules! field_common {
         fn square(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let v: Vec<$f_type> = (0..SAMPLES).map(|_| $f::rand(&mut rng)).collect();
 
@@ -194,7 +194,7 @@ macro_rules! field_common {
         fn inverse(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let v: Vec<$f_type> = (0..SAMPLES).map(|_| $f::rand(&mut rng)).collect();
 
@@ -210,7 +210,7 @@ macro_rules! field_common {
             use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let mut num_bytes = 0;
             let v: Vec<_> = (0..SAMPLES)
@@ -235,7 +235,7 @@ macro_rules! field_common {
             use ark_serialize::CanonicalSerialize;
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let v: Vec<$f_type> = (0..SAMPLES).map(|_| $f::rand(&mut rng)).collect();
             let mut bytes = Vec::with_capacity(1000);
@@ -253,7 +253,7 @@ macro_rules! field_common {
             use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let mut num_bytes = 0;
             let v: Vec<_> = (0..SAMPLES)
@@ -278,7 +278,7 @@ macro_rules! field_common {
             use ark_serialize::CanonicalSerialize;
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let v: Vec<$f_type> = (0..SAMPLES).map(|_| $f::rand(&mut rng)).collect();
             let mut bytes = Vec::with_capacity(1000);
@@ -300,7 +300,7 @@ macro_rules! sqrt {
         pub fn sqrt(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let v: Vec<$f_type> = (0..SAMPLES)
                 .map(|_| {
@@ -325,7 +325,7 @@ macro_rules! prime_field {
         fn repr_add_nocarry(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let v: Vec<_> = (0..SAMPLES)
                 .map(|_| {
@@ -352,7 +352,7 @@ macro_rules! prime_field {
         fn repr_sub_noborrow(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let v: Vec<_> = (0..SAMPLES)
                 .map(|_| {
@@ -378,7 +378,7 @@ macro_rules! prime_field {
         fn repr_num_bits(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let v: Vec<$f_repr_type> = (0..SAMPLES).map(|_| $f_repr::rand(&mut rng)).collect();
 
@@ -393,7 +393,7 @@ macro_rules! prime_field {
         fn repr_mul2(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let v: Vec<$f_repr_type> = (0..SAMPLES).map(|_| $f_repr::rand(&mut rng)).collect();
 
@@ -409,7 +409,7 @@ macro_rules! prime_field {
         fn repr_div2(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let v: Vec<$f_repr_type> = (0..SAMPLES).map(|_| $f_repr::rand(&mut rng)).collect();
 
@@ -425,7 +425,7 @@ macro_rules! prime_field {
         fn into_repr(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let v: Vec<$f_type> = (0..SAMPLES).map(|_| $f::rand(&mut rng)).collect();
 
@@ -439,7 +439,7 @@ macro_rules! prime_field {
         fn from_repr(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let v: Vec<$f_repr_type> = (0..SAMPLES)
                 .map(|_| $f::rand(&mut rng).into_repr())

--- a/curve-benches/src/macros/pairing.rs
+++ b/curve-benches/src/macros/pairing.rs
@@ -4,7 +4,7 @@ macro_rules! pairing_bench {
         fn miller_loop(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let g1s = (0..SAMPLES).map(|_| G1::rand(&mut rng)).collect::<Vec<_>>();
             let g2s = (0..SAMPLES).map(|_| G2::rand(&mut rng)).collect::<Vec<_>>();
@@ -30,7 +30,7 @@ macro_rules! pairing_bench {
         fn final_exponentiation(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let v: Vec<_> = (0..SAMPLES)
                 .map(|_| {
@@ -53,7 +53,7 @@ macro_rules! pairing_bench {
         fn full_pairing(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = ark_std::test_rng();
 
             let v: Vec<(G1, G2)> = (0..SAMPLES)
                 .map(|_| (G1::rand(&mut rng), G2::rand(&mut rng)))

--- a/curve-constraint-tests/Cargo.toml
+++ b/curve-constraint-tests/Cargo.toml
@@ -19,8 +19,6 @@ ark-ff = { git = "https://github.com/arkworks-rs/algebra", default-features = fa
 ark-relations = { git = "https://github.com/arkworks-rs/snark", default-features = false }
 ark-r1cs-std = {  git = "https://github.com/arkworks-rs/r1cs-std", default-features = false }
 ark-ec = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
-rand = { version = "0.7", default-features = false}
-rand_xorshift = { version = "0.2", default-features = false}
 
 [features]
 default = []

--- a/curve-constraint-tests/src/lib.rs
+++ b/curve-constraint-tests/src/lib.rs
@@ -2,9 +2,6 @@
 extern crate ark_relations;
 
 pub mod fields {
-    use rand::{self, SeedableRng};
-    use rand_xorshift::XorShiftRng;
-
     use ark_ff::{BitIteratorLE, Field, UniformRand};
     use ark_r1cs_std::prelude::*;
     use ark_relations::r1cs::{ConstraintSystem, SynthesisError};
@@ -217,7 +214,7 @@ pub mod fields {
         ];
         for &mode in &modes {
             let cs = ConstraintSystem::<ConstraintF>::new_ref();
-            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+            let mut rng = test_rng();
             for i in 0..=maxpower {
                 let mut a = F::rand(&mut rng);
                 let mut a_gadget = AF::new_variable(ark_relations::ns!(cs, "a"), || Ok(a), mode)?;

--- a/ed_on_bls12_377/src/curves/tests.rs
+++ b/ed_on_bls12_377/src/curves/tests.rs
@@ -1,6 +1,6 @@
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_std::test_rng;
-use rand::Rng;
+use ark_std::rand::Rng;
 
 use crate::*;
 

--- a/ed_on_bls12_377/src/curves/tests.rs
+++ b/ed_on_bls12_377/src/curves/tests.rs
@@ -1,6 +1,6 @@
 use ark_ec::{AffineCurve, ProjectiveCurve};
-use ark_std::test_rng;
 use ark_std::rand::Rng;
+use ark_std::test_rng;
 
 use crate::*;
 

--- a/ed_on_bls12_377/src/fields/tests.rs
+++ b/ed_on_bls12_377/src/fields/tests.rs
@@ -1,5 +1,5 @@
 use ark_std::test_rng;
-use rand::Rng;
+use ark_std::rand::Rng;
 
 use crate::{Fq, Fr};
 

--- a/ed_on_bls12_377/src/fields/tests.rs
+++ b/ed_on_bls12_377/src/fields/tests.rs
@@ -1,5 +1,5 @@
-use ark_std::test_rng;
 use ark_std::rand::Rng;
+use ark_std::test_rng;
 
 use crate::{Fq, Fr};
 

--- a/ed_on_bls12_381/Cargo.toml
+++ b/ed_on_bls12_381/Cargo.toml
@@ -24,8 +24,6 @@ ark-relations = { git = "https://github.com/arkworks-rs/snark", default-features
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-curve-constraint-tests = { path = "../curve-constraint-tests", default-features = false }
-rand = { version = "0.7", default-features = false }
-rand_xorshift = "0.2"
 
 [features]
 default = []

--- a/ed_on_bls12_381/src/curves/tests.rs
+++ b/ed_on_bls12_381/src/curves/tests.rs
@@ -1,8 +1,8 @@
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{bytes::FromBytes, Zero};
-use ark_std::test_rng;
-use ark_std::str::FromStr;
 use ark_std::rand::Rng;
+use ark_std::str::FromStr;
+use ark_std::test_rng;
 
 use crate::*;
 

--- a/ed_on_bls12_381/src/curves/tests.rs
+++ b/ed_on_bls12_381/src/curves/tests.rs
@@ -1,8 +1,8 @@
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{bytes::FromBytes, Zero};
 use ark_std::test_rng;
-use core::str::FromStr;
-use rand::Rng;
+use ark_std::str::FromStr;
+use ark_std::rand::Rng;
 
 use crate::*;
 

--- a/ed_on_bls12_381/src/fields/tests.rs
+++ b/ed_on_bls12_381/src/fields/tests.rs
@@ -9,8 +9,8 @@ use ark_std::test_rng;
 
 use ark_algebra_test_templates::fields::*;
 
-use ark_std::str::FromStr;
 use ark_std::rand::Rng;
+use ark_std::str::FromStr;
 
 #[test]
 fn test_fr() {

--- a/ed_on_bls12_381/src/fields/tests.rs
+++ b/ed_on_bls12_381/src/fields/tests.rs
@@ -9,8 +9,8 @@ use ark_std::test_rng;
 
 use ark_algebra_test_templates::fields::*;
 
-use core::str::FromStr;
-use rand::Rng;
+use ark_std::str::FromStr;
+use ark_std::rand::Rng;
 
 #[test]
 fn test_fr() {

--- a/ed_on_bn254/Cargo.toml
+++ b/ed_on_bn254/Cargo.toml
@@ -24,8 +24,6 @@ ark-relations = { git = "https://github.com/arkworks-rs/snark", default-features
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-curve-constraint-tests = { path = "../curve-constraint-tests", default-features = false }
-rand = { version = "0.7", default-features = false }
-rand_xorshift = "0.2"
 
 [features]
 default = []

--- a/ed_on_bn254/src/curves/tests.rs
+++ b/ed_on_bn254/src/curves/tests.rs
@@ -1,8 +1,8 @@
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{bytes::FromBytes, Zero};
-use ark_std::test_rng;
-use ark_std::str::FromStr;
 use ark_std::rand::Rng;
+use ark_std::str::FromStr;
+use ark_std::test_rng;
 
 use crate::*;
 

--- a/ed_on_bn254/src/curves/tests.rs
+++ b/ed_on_bn254/src/curves/tests.rs
@@ -1,8 +1,8 @@
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{bytes::FromBytes, Zero};
 use ark_std::test_rng;
-use core::str::FromStr;
-use rand::Rng;
+use ark_std::str::FromStr;
+use ark_std::rand::Rng;
 
 use crate::*;
 

--- a/ed_on_bn254/src/fields/tests.rs
+++ b/ed_on_bn254/src/fields/tests.rs
@@ -9,8 +9,8 @@ use ark_std::test_rng;
 
 use ark_algebra_test_templates::fields::*;
 
-use ark_std::str::FromStr;
 use ark_std::rand::Rng;
+use ark_std::str::FromStr;
 
 #[test]
 fn test_fr() {

--- a/ed_on_bn254/src/fields/tests.rs
+++ b/ed_on_bn254/src/fields/tests.rs
@@ -9,8 +9,8 @@ use ark_std::test_rng;
 
 use ark_algebra_test_templates::fields::*;
 
-use core::str::FromStr;
-use rand::Rng;
+use ark_std::str::FromStr;
+use ark_std::rand::Rng;
 
 #[test]
 fn test_fr() {

--- a/ed_on_cp6_782/Cargo.toml
+++ b/ed_on_cp6_782/Cargo.toml
@@ -24,8 +24,6 @@ ark-relations = { git = "https://github.com/arkworks-rs/snark", default-features
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-curve-constraint-tests = { path = "../curve-constraint-tests", default-features = false }
-rand = { version = "0.7", default-features = false }
-rand_xorshift = "0.2"
 
 [features]
 default = []

--- a/ed_on_cp6_782/src/curves/tests.rs
+++ b/ed_on_cp6_782/src/curves/tests.rs
@@ -1,6 +1,6 @@
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_std::test_rng;
-use ark_std::Rng;
+use ark_std::rand::Rng;
 
 use crate::*;
 

--- a/ed_on_cp6_782/src/curves/tests.rs
+++ b/ed_on_cp6_782/src/curves/tests.rs
@@ -1,6 +1,6 @@
 use ark_ec::{AffineCurve, ProjectiveCurve};
-use ark_std::test_rng;
 use ark_std::rand::Rng;
+use ark_std::test_rng;
 
 use crate::*;
 

--- a/ed_on_cp6_782/src/curves/tests.rs
+++ b/ed_on_cp6_782/src/curves/tests.rs
@@ -1,6 +1,6 @@
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_std::test_rng;
-use rand::Rng;
+use ark_std::Rng;
 
 use crate::*;
 

--- a/ed_on_cp6_782/src/fields/tests.rs
+++ b/ed_on_cp6_782/src/fields/tests.rs
@@ -1,5 +1,5 @@
 use ark_std::test_rng;
-use rand::Rng;
+use ark_std::rand::Rng;
 
 use crate::{Fq, Fr};
 

--- a/ed_on_cp6_782/src/fields/tests.rs
+++ b/ed_on_cp6_782/src/fields/tests.rs
@@ -1,5 +1,5 @@
-use ark_std::test_rng;
 use ark_std::rand::Rng;
+use ark_std::test_rng;
 
 use crate::{Fq, Fr};
 

--- a/ed_on_mnt4_298/Cargo.toml
+++ b/ed_on_mnt4_298/Cargo.toml
@@ -24,8 +24,6 @@ ark-relations = { git = "https://github.com/arkworks-rs/snark", default-features
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-curve-constraint-tests = { path = "../curve-constraint-tests", default-features = false }
-rand = { version = "0.7", default-features = false }
-rand_xorshift = "0.2"
 
 [features]
 default = []

--- a/ed_on_mnt4_298/src/curves/tests.rs
+++ b/ed_on_mnt4_298/src/curves/tests.rs
@@ -1,6 +1,6 @@
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_std::test_rng;
-use rand::Rng;
+use ark_std::rand::Rng;
 
 use crate::*;
 

--- a/ed_on_mnt4_298/src/curves/tests.rs
+++ b/ed_on_mnt4_298/src/curves/tests.rs
@@ -1,6 +1,6 @@
 use ark_ec::{AffineCurve, ProjectiveCurve};
-use ark_std::test_rng;
 use ark_std::rand::Rng;
+use ark_std::test_rng;
 
 use crate::*;
 

--- a/ed_on_mnt4_298/src/fields/tests.rs
+++ b/ed_on_mnt4_298/src/fields/tests.rs
@@ -1,5 +1,5 @@
 use ark_std::test_rng;
-use rand::Rng;
+use ark_std::rand::Rng;
 
 use crate::fields::*;
 

--- a/ed_on_mnt4_298/src/fields/tests.rs
+++ b/ed_on_mnt4_298/src/fields/tests.rs
@@ -1,5 +1,5 @@
-use ark_std::test_rng;
 use ark_std::rand::Rng;
+use ark_std::test_rng;
 
 use crate::fields::*;
 

--- a/ed_on_mnt4_753/Cargo.toml
+++ b/ed_on_mnt4_753/Cargo.toml
@@ -24,8 +24,6 @@ ark-relations = { git = "https://github.com/arkworks-rs/snark", default-features
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-curve-constraint-tests = { path = "../curve-constraint-tests", default-features = false }
-rand = { version = "0.7", default-features = false }
-rand_xorshift = "0.2"
 
 [features]
 default = []

--- a/ed_on_mnt4_753/src/curves/tests.rs
+++ b/ed_on_mnt4_753/src/curves/tests.rs
@@ -1,6 +1,6 @@
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_std::test_rng;
-use rand::Rng;
+use ark_std::rand::Rng;
 
 use crate::*;
 

--- a/ed_on_mnt4_753/src/fields/tests.rs
+++ b/ed_on_mnt4_753/src/fields/tests.rs
@@ -1,5 +1,5 @@
 use ark_std::test_rng;
-use rand::Rng;
+use ark_std::rand::Rng;
 
 use crate::{Fq, Fr};
 use ark_algebra_test_templates::fields::*;

--- a/mnt4_298/Cargo.toml
+++ b/mnt4_298/Cargo.toml
@@ -23,8 +23,6 @@ ark-relations = { git = "https://github.com/arkworks-rs/snark", default-features
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-curve-constraint-tests = { path = "../curve-constraint-tests", default-features = false }
-rand = { version = "0.7", default-features = false }
-rand_xorshift = "0.2"
 
 [features]
 default = [ "curve" ]

--- a/mnt4_298/src/curves/tests.rs
+++ b/mnt4_298/src/curves/tests.rs
@@ -1,7 +1,7 @@
 use ark_ec::{AffineCurve, PairingEngine, ProjectiveCurve};
 use ark_ff::{Field, One, PrimeField, UniformRand};
 use ark_std::test_rng;
-use rand::Rng;
+use ark_std::rand::Rng;
 
 use crate::*;
 

--- a/mnt4_298/src/curves/tests.rs
+++ b/mnt4_298/src/curves/tests.rs
@@ -1,7 +1,7 @@
 use ark_ec::{AffineCurve, PairingEngine, ProjectiveCurve};
 use ark_ff::{Field, One, PrimeField, UniformRand};
-use ark_std::test_rng;
 use ark_std::rand::Rng;
+use ark_std::test_rng;
 
 use crate::*;
 

--- a/mnt4_298/src/fields/tests.rs
+++ b/mnt4_298/src/fields/tests.rs
@@ -1,6 +1,6 @@
 use ark_ff::Field;
-use ark_std::test_rng;
 use ark_std::rand::Rng;
+use ark_std::test_rng;
 
 use crate::*;
 

--- a/mnt4_298/src/fields/tests.rs
+++ b/mnt4_298/src/fields/tests.rs
@@ -1,6 +1,6 @@
 use ark_ff::Field;
 use ark_std::test_rng;
-use rand::Rng;
+use ark_std::rand::Rng;
 
 use crate::*;
 

--- a/mnt4_753/Cargo.toml
+++ b/mnt4_753/Cargo.toml
@@ -23,8 +23,6 @@ ark-relations = { git = "https://github.com/arkworks-rs/snark", default-features
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-curve-constraint-tests = { path = "../curve-constraint-tests", default-features = false }
-rand = { version = "0.7", default-features = false }
-rand_xorshift = "0.2"
 
 [features]
 default = [ "curve" ]

--- a/mnt4_753/src/curves/tests.rs
+++ b/mnt4_753/src/curves/tests.rs
@@ -1,7 +1,7 @@
 use ark_ec::{AffineCurve, PairingEngine, ProjectiveCurve};
 use ark_ff::{Field, One, PrimeField, UniformRand};
 use ark_std::test_rng;
-use rand::Rng;
+use ark_std::rand::Rng;
 
 use crate::*;
 

--- a/mnt4_753/src/curves/tests.rs
+++ b/mnt4_753/src/curves/tests.rs
@@ -1,7 +1,7 @@
 use ark_ec::{AffineCurve, PairingEngine, ProjectiveCurve};
 use ark_ff::{Field, One, PrimeField, UniformRand};
-use ark_std::test_rng;
 use ark_std::rand::Rng;
+use ark_std::test_rng;
 
 use crate::*;
 

--- a/mnt4_753/src/fields/tests.rs
+++ b/mnt4_753/src/fields/tests.rs
@@ -1,6 +1,6 @@
 use ark_ff::Field;
-use ark_std::test_rng;
 use ark_std::rand::Rng;
+use ark_std::test_rng;
 
 use crate::*;
 

--- a/mnt4_753/src/fields/tests.rs
+++ b/mnt4_753/src/fields/tests.rs
@@ -1,6 +1,6 @@
 use ark_ff::Field;
 use ark_std::test_rng;
-use rand::Rng;
+use ark_std::rand::Rng;
 
 use crate::*;
 

--- a/mnt6_298/Cargo.toml
+++ b/mnt6_298/Cargo.toml
@@ -24,8 +24,6 @@ ark-relations = { git = "https://github.com/arkworks-rs/snark", default-features
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-curve-constraint-tests = { path = "../curve-constraint-tests", default-features = false }
-rand = { version = "0.7", default-features = false }
-rand_xorshift = "0.2"
 
 [features]
 default = []

--- a/mnt6_298/src/curves/tests.rs
+++ b/mnt6_298/src/curves/tests.rs
@@ -1,7 +1,7 @@
 use ark_ec::{AffineCurve, PairingEngine, ProjectiveCurve};
 use ark_ff::{Field, One, PrimeField, UniformRand};
 use ark_std::test_rng;
-use rand::Rng;
+use ark_std::rand::Rng;
 
 use crate::*;
 

--- a/mnt6_298/src/curves/tests.rs
+++ b/mnt6_298/src/curves/tests.rs
@@ -1,7 +1,7 @@
 use ark_ec::{AffineCurve, PairingEngine, ProjectiveCurve};
 use ark_ff::{Field, One, PrimeField, UniformRand};
-use ark_std::test_rng;
 use ark_std::rand::Rng;
+use ark_std::test_rng;
 
 use crate::*;
 

--- a/mnt6_298/src/fields/tests.rs
+++ b/mnt6_298/src/fields/tests.rs
@@ -2,8 +2,8 @@ use ark_ff::{
     fields::{models::fp6_2over3::*, quadratic_extension::QuadExtParameters},
     Field,
 };
-use ark_std::test_rng;
 use ark_std::rand::Rng;
+use ark_std::test_rng;
 
 use crate::*;
 

--- a/mnt6_298/src/fields/tests.rs
+++ b/mnt6_298/src/fields/tests.rs
@@ -3,7 +3,7 @@ use ark_ff::{
     Field,
 };
 use ark_std::test_rng;
-use rand::Rng;
+use ark_std::rand::Rng;
 
 use crate::*;
 

--- a/mnt6_753/Cargo.toml
+++ b/mnt6_753/Cargo.toml
@@ -24,8 +24,6 @@ ark-relations = { git = "https://github.com/arkworks-rs/snark", default-features
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-curve-constraint-tests = { path = "../curve-constraint-tests", default-features = false }
-rand = { version = "0.7", default-features = false }
-rand_xorshift = "0.2"
 
 [features]
 default = []

--- a/mnt6_753/src/curves/tests.rs
+++ b/mnt6_753/src/curves/tests.rs
@@ -1,7 +1,7 @@
 use ark_ec::{AffineCurve, PairingEngine, ProjectiveCurve};
 use ark_ff::{Field, One, PrimeField, UniformRand};
 use ark_std::test_rng;
-use rand::Rng;
+use ark_std::rand::Rng;
 
 use crate::*;
 

--- a/mnt6_753/src/curves/tests.rs
+++ b/mnt6_753/src/curves/tests.rs
@@ -1,7 +1,7 @@
 use ark_ec::{AffineCurve, PairingEngine, ProjectiveCurve};
 use ark_ff::{Field, One, PrimeField, UniformRand};
-use ark_std::test_rng;
 use ark_std::rand::Rng;
+use ark_std::test_rng;
 
 use crate::*;
 

--- a/mnt6_753/src/fields/tests.rs
+++ b/mnt6_753/src/fields/tests.rs
@@ -2,8 +2,8 @@ use ark_ff::{
     fields::{models::fp6_2over3::*, quadratic_extension::QuadExtParameters},
     Field,
 };
-use ark_std::test_rng;
 use ark_std::rand::Rng;
+use ark_std::test_rng;
 
 use crate::*;
 

--- a/mnt6_753/src/fields/tests.rs
+++ b/mnt6_753/src/fields/tests.rs
@@ -3,7 +3,7 @@ use ark_ff::{
     Field,
 };
 use ark_std::test_rng;
-use rand::Rng;
+use ark_std::rand::Rng;
 
 use crate::*;
 

--- a/pallas/Cargo.toml
+++ b/pallas/Cargo.toml
@@ -23,8 +23,6 @@ ark-relations = { git = "https://github.com/arkworks-rs/snark", default-features
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-curve-constraint-tests = { path = "../curve-constraint-tests", default-features = false }
-rand = { version = "0.7", default-features = false }
-rand_xorshift = "0.2"
 
 [features]
 default = [ "curve" ]

--- a/pallas/src/curves/tests.rs
+++ b/pallas/src/curves/tests.rs
@@ -7,8 +7,8 @@ use ark_serialize::CanonicalSerialize;
 use ark_std::test_rng;
 
 use ark_ec::{models::SWModelParameters, AffineCurve, PairingEngine, ProjectiveCurve};
-use core::ops::{AddAssign, MulAssign};
-use rand::Rng;
+use ark_std::ops::{AddAssign, MulAssign};
+use ark_std::rand::Rng;
 
 use crate::{Affine, PallasParameters, Projective};
 

--- a/pallas/src/fields/tests.rs
+++ b/pallas/src/fields/tests.rs
@@ -1,5 +1,5 @@
-use ark_std::test_rng;
 use ark_std::rand::Rng;
+use ark_std::test_rng;
 
 use crate::*;
 

--- a/pallas/src/fields/tests.rs
+++ b/pallas/src/fields/tests.rs
@@ -1,5 +1,5 @@
 use ark_std::test_rng;
-use rand::Rng;
+use ark_std::rand::Rng;
 
 use crate::*;
 

--- a/vesta/Cargo.toml
+++ b/vesta/Cargo.toml
@@ -24,8 +24,6 @@ ark-relations = { git = "https://github.com/arkworks-rs/snark", default-features
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-curve-constraint-tests = { path = "../curve-constraint-tests", default-features = false }
-rand = { version = "0.7", default-features = false }
-rand_xorshift = "0.2"
 
 [features]
 default = []

--- a/vesta/src/curves/tests.rs
+++ b/vesta/src/curves/tests.rs
@@ -7,8 +7,8 @@ use ark_serialize::CanonicalSerialize;
 use ark_std::test_rng;
 
 use ark_ec::{models::SWModelParameters, AffineCurve, PairingEngine, ProjectiveCurve};
-use core::ops::{AddAssign, MulAssign};
-use rand::Rng;
+use ark_std::ops::{AddAssign, MulAssign};
+use ark_std::rand::Rng;
 
 use crate::{Affine, Projective, VestaParameters};
 

--- a/vesta/src/fields/tests.rs
+++ b/vesta/src/fields/tests.rs
@@ -1,5 +1,5 @@
-use ark_std::test_rng;
 use ark_std::rand::Rng;
+use ark_std::test_rng;
 
 use crate::*;
 

--- a/vesta/src/fields/tests.rs
+++ b/vesta/src/fields/tests.rs
@@ -1,5 +1,5 @@
 use ark_std::test_rng;
-use rand::Rng;
+use ark_std::rand::Rng;
 
 use crate::*;
 


### PR DESCRIPTION
## Description

Many of the tests in the curve implementations use `rand`. Given that now we have `ark_std::rand`, we replace them with it. We also remove the use of `rand_xorshift`.

---

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
