### PR TITLE
Remove the two remaining direct references to `rand`

### DIFF
--- a/cp6_782/Cargo.toml
+++ b/cp6_782/Cargo.toml
@@ -21,8 +21,6 @@ ark-bls12-377 = { path = "../bls12_377", default-features = false, features = [ 
 [dev-dependencies]
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
-rand = { version = "0.7", default-features = false }
-rand_xorshift = "0.2"
 
 [features]
 default = []

--- a/ed_on_bls12_377/Cargo.toml
+++ b/ed_on_bls12_377/Cargo.toml
@@ -24,8 +24,6 @@ ark-relations = { git = "https://github.com/arkworks-rs/snark", default-features
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-curve-constraint-tests = { path = "../curve-constraint-tests", default-features = false }
-rand = { version = "0.7", default-features = false }
-rand_xorshift = "0.2"
 
 [features]
 default = []


### PR DESCRIPTION
## Description

The code has two remaining references to `rand` and `rand_xorshift`, though they are not being used.

This PR simplifies remove these unused dependencies from the `Cargo.toml`.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`---N/A, this is a very small edit that does not has an actual effect unless the rand version in std is up.
- [x] Re-reviewed `Files changed` in the Github PR explorer
