### PR TITLE
Reduce CI time by parallelizing per-curve tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,9 @@ jobs:
         #   - stable
         #   - nightly
         exclude:
-          - dir: [ "scripts/", "curve-constraint-tests/", "curve-benches/" ]
+          - dir: scripts/
+          - dir: curve-constraint-tests/
+          - dir: curve-benches/
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         command: fmt
         args: --all -- --check
 
-  test:
+  check:
     name: Check
     runs-on: ubuntu-latest
     env:
@@ -83,39 +83,39 @@ jobs:
       - id: set-dirs # Give it an id to handle to get step outputs in the outputs key above
         run: echo "::set-output name=dir::$(ls -d */ | jq -R -s -c 'split("\n")[:-1]')"
         # Define step output named dir base on ls command transformed to JSON thanks to jq
-  loop:
+  test:
     name: Test
     runs-on: ubuntu-latest
     needs: [directories] # Depends on previous job
     strategy:
       matrix:
         dir: ${{fromJson(needs.directories.outputs.dir)}} # List matrix strategy from directories dynamically
-        rust:
-          - stable
-          - nightly
+        # rust:
+        #   - stable
+        #   - nightly
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install Rust (${{ matrix.rust }})
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
 
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - run: cd ${{matrix.dir}}
-      - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-            command: test
-            args: "--all-features"
+      # - name: Install Rust (${{ matrix.rust }})
+      #   uses: actions-rs/toolchain@v1
+      #   with:
+      #     profile: minimal
+      #     toolchain: ${{ matrix.rust }}
+      #     override: true
+
+      # - uses: actions/cache@v2
+      #   with:
+      #     path: |
+      #       ~/.cargo/registry
+      #       ~/.cargo/git
+      #       target
+      #     key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - run: |
+          ls
+          cd ${{matrix.dir}}
+          pwd
+          cargo test --all-features
 
   docs:
     name: Check Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
         # rust:
         #   - stable
         #   - nightly
-    if: matrix.dir != 'scripts' || matrix.dir != 'curve-constraint-tests' || matrix.dir != 'curve-benches'
+    if: ${{matrix.dir}} != 'scripts' || ${{matrix.dir}} != 'curve-constraint-tests' || ${{matrix.dir}} != 'curve-benches'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,13 @@ jobs:
             args: --examples --all-features --all
         if: matrix.rust == 'stable'
 
+      - name: Check benchmarks on nightly
+        uses: actions-rs/cargo@v1
+        with:
+            command: check
+            args: --all-features --examples --workspace --benches
+        if: matrix.rust == 'nightly'
+
       
 
   directories: # Job that list subdirectories
@@ -93,24 +100,10 @@ jobs:
         # rust:
         #   - stable
         #   - nightly
+    if: matrix.dir != 'scripts' || matrix.dir != 'curve-constraint-tests' || matrix.dir != 'curve-benches'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      # - name: Install Rust (${{ matrix.rust }})
-      #   uses: actions-rs/toolchain@v1
-      #   with:
-      #     profile: minimal
-      #     toolchain: ${{ matrix.rust }}
-      #     override: true
-
-      # - uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       ~/.cargo/registry
-      #       ~/.cargo/git
-      #       target
-      #     key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: |
           ls
           cd ${{matrix.dir}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,10 +104,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - run: |
-          ls
+      - name: Run tests
+        run: |
           cd ${{matrix.dir}}
-          pwd
           cargo test --all-features
 
   docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         args: --all -- --check
 
   test:
-    name: Test
+    name: Check
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -Dwarnings
@@ -71,20 +71,51 @@ jobs:
             args: --examples --all-features --all
         if: matrix.rust == 'stable'
 
-      - name: Check benchmarks on nightly
-        uses: actions-rs/cargo@v1
-        with:
-            command: check
-            args: --all-features --examples --workspace --benches
-        if: matrix.rust == 'nightly'
+      
 
+  directories: # Job that list subdirectories
+    name: List directories for parallelizing tests
+    runs-on: ubuntu-latest
+    outputs:
+      dir: ${{ steps.set-dirs.outputs.dir }} # generate output name dir by using inner step output
+    steps:
+      - uses: actions/checkout@v2
+      - id: set-dirs # Give it an id to handle to get step outputs in the outputs key above
+        run: echo "::set-output name=dir::$(ls -d */ | jq -R -s -c 'split("\n")[:-1]')"
+        # Define step output named dir base on ls command transformed to JSON thanks to jq
+  loop:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: [directories] # Depends on previous job
+    strategy:
+      matrix:
+        dir: ${{fromJson(needs.directories.outputs.dir)}} # List matrix strategy from directories dynamically
+        rust:
+          - stable
+          - nightly
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Rust (${{ matrix.rust }})
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - run: cd ${{matrix.dir}}
       - name: Test
         uses: actions-rs/cargo@v1
         with:
             command: test
-            args: "--workspace \
-                   --all-features \
-                   --exclude curve-benches"
+            args: "--all-features"
 
   docs:
     name: Check Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,8 @@ jobs:
         # rust:
         #   - stable
         #   - nightly
-    if: ${{matrix.dir}} != 'scripts' || ${{matrix.dir}} != 'curve-constraint-tests' || ${{matrix.dir}} != 'curve-benches'
+        exclude:
+          - dir: [ "scripts/", "curve-constraint-tests/", "curve-benches/" ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
As in title. Reduces the total CI time from 22-25 minutes down to 5.5 minutes. The primary downside of this is that we're running ~23 jobs in parallel, and Github actions only allows 20 actions in parallel; this means that if we have multiple PRs in flight, and they all need CI at the same time, some PRs will have to wait. To further limit the number of parallel jobs, `cargo test` now runs only against `stable`, and not also `nightly` (`cargo check` still runs against both).

However this repo doesn't usually see a lot of concurrent PRs, so I don't think it's too much of a worry.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [X] Targeted PR against correct branch (master)
- [X] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests (N/A)
- [X] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md` (N/A)
- [X] Re-reviewed `Files changed` in the Github PR explorer
