### PR TITLE
Fix Bls12-377 scalar group generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Pending 
+
+### Breaking changes
+- [\#60](https://github.com/arkworks-rs/curves/pull/60) Change the scalar group generator of `Fr` of `bls12_377` Fr from `11` to `22`.
+
+### Features
+
+### Improvements
+
+### Bug fixes
+
 ## v0.2.0
 
 ### Breaking changes

--- a/bls12_377/src/fields/fr.rs
+++ b/bls12_377/src/fields/fr.rs
@@ -1,3 +1,24 @@
+///! Bls12-377 scalar field.
+///
+/// Roots of unity computed from modulus and R using this sage code:
+///
+/// ```ignore
+/// q = 8444461749428370424248824938781546531375899335154063827935233455917409239041
+/// R = 6014086494747379908336260804527802945383293308637734276299549080986809532403 # Montgomery R
+/// s = 47
+/// o = q - 1
+/// F = GF(q)
+/// g = F.multiplicative_generator()
+/// g = F.multiplicative_generator()
+/// assert g.multiplicative_order() == o
+/// g2 = g ** (o/2**s)
+/// assert g2.multiplicative_order() == 2**s
+/// def into_chunks(val, width, n):
+///     return [int(int(val) // (2 ** (width * i)) % 2 ** width) for i in range(n)]
+/// print("Gen: ", g * R % q)
+/// print("Gen: ", into_chunks(g * R % q, 64, 4))
+/// print("2-adic gen: ", into_chunks(g2 * R % q, 64, 4))
+/// ```
 use ark_ff::{biginteger::BigInteger256 as BigInteger, fields::*};
 
 pub type Fr = Fp256<FrParameters>;
@@ -12,10 +33,10 @@ impl FftParameters for FrParameters {
 
     #[rustfmt::skip]
     const TWO_ADIC_ROOT_OF_UNITY: BigInteger = BigInteger([
-        0x3c3d3ca739381fb2,
-        0x9a14cda3ec99772b,
-        0xd7aacc7c59724826,
-        0xd1ba211c5cc349c,
+        12646347781564978760u64,
+        6783048705277173164u64,
+        268534165941069093u64,
+        1121515446318641358u64,
     ]);
 }
 impl FpParameters for FrParameters {
@@ -53,15 +74,15 @@ impl FpParameters for FrParameters {
 
     const INV: u64 = 725501752471715839u64;
 
-    /// GENERATOR = 11
+    /// GENERATOR = 22
     /// Encoded in Montgomery form, so the value is
-    /// (11 * R) % q = 7043719196222586021957094278335006679584931048936630243748405699433040183146
+    /// (22 * R) % q = 5642976643016801619665363617888466827793962762719196659561577942948671127251
     #[rustfmt::skip]
     const GENERATOR: BigInteger = BigInteger([
-        1855201571499933546u64,
-        8511318076631809892u64,
-        6222514765367795509u64,
-        1122129207579058019u64,
+        2984901390528151251u64,
+        10561528701063790279u64,
+        5476750214495080041u64,
+        898978044469942640u64,
     ]);
 
     /// (r - 1)/2 =


### PR DESCRIPTION
Previously we used 11 as a generator, which has order (p-1)/35.

Now we use 22, which has the right order.

Fixed the two-adic root of unity in accordance with the new generator.

fixes #57 

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
