### PR TITLE
Use Scott's subgroup membership tests for `G1` and `G2` of BLS12-381.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Improvements
 
+- [\#74](https://github.com/arkworks-rs/curves/pull/74) Use Scott's subgroup membership tests for `G1` and `G2` of BLS12-381.
+
 ### Bug fixes
 
 ## v0.3.0 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,8 @@ lto = "thin"
 incremental = true
 debug-assertions = true
 debug = true
+
+[patch.crates-io]
+ark-ec = { git="https://github.com/arkworks-rs/algebra.git", path="ec/" }
+ark-ff = { git="https://github.com/arkworks-rs/algebra.git", path="ff/" }
+ark-serialize = { git="https://github.com/arkworks-rs/algebra.git", path="serialize/" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,6 @@ debug-assertions = true
 debug = true
 
 [patch.crates-io]
-ark-ec = { git="https://github.com/arkworks-rs/algebra.git", path="ec/" }
-ark-ff = { git="https://github.com/arkworks-rs/algebra.git", path="ff/" }
-ark-serialize = { git="https://github.com/arkworks-rs/algebra.git", path="serialize/" }
+ark-ec = { git="https://github.com/arkworks-rs/algebra" }
+ark-ff = { git="https://github.com/arkworks-rs/algebra" }
+ark-serialize = { git="https://github.com/arkworks-rs/algebra" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,6 @@ debug-assertions = true
 debug = true
 
 [patch.crates-io]
-ark-ec = { git="https://github.com/arkworks-rs/algebra" }
-ark-ff = { git="https://github.com/arkworks-rs/algebra" }
-ark-serialize = { git="https://github.com/arkworks-rs/algebra" }
+ark-ec = { git = "https://github.com/arkworks-rs/algebra" }
+ark-ff = { git = "https://github.com/arkworks-rs/algebra" }
+ark-serialize = { git = "https://github.com/arkworks-rs/algebra" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ incremental = true
 debug-assertions = true
 debug = true
 
+# To be removed in the new release.
 [patch.crates-io]
 ark-ec = { git = "https://github.com/arkworks-rs/algebra" }
 ark-ff = { git = "https://github.com/arkworks-rs/algebra" }

--- a/bls12_381/src/curves/g1.rs
+++ b/bls12_381/src/curves/g1.rs
@@ -50,16 +50,15 @@ impl SWModelParameters for Parameters {
             true
         } else {
             let sigma_p = sigma(p);
-	    // TODO
-            let mut x_times_p =
-                p.mul(BigInteger([crate::Parameters::X[0], 0, 0, 0]));
+            // TODO
+            let mut x_times_p = p.mul(BigInteger([crate::Parameters::X[0], 0, 0, 0]));
             if crate::Parameters::X_IS_NEGATIVE {
                 x_times_p = -x_times_p;
             }
             if x_times_p.add_mixed(p).is_zero() {
                 false
             } else {
-		// TODO
+                // TODO
                 let mut x2_times_p = x_times_p.mul(BigInteger([crate::Parameters::X[0], 0, 0, 0]));
                 if crate::Parameters::X_IS_NEGATIVE {
                     x2_times_p = -x2_times_p;

--- a/bls12_381/src/curves/g1.rs
+++ b/bls12_381/src/curves/g1.rs
@@ -49,24 +49,22 @@ impl SWModelParameters for Parameters {
         // if [X]P = P during the computation, return False
         if p.is_zero() {
             true
-        }
-        else {
+        } else {
             let sigma_p = sigma(p);
             let mut x_times_p: GroupAffine<_> =
-                p.mul(BigInteger([Parameters0::X[0], 0, 0,
-				  0])).into();
-	    if Parameters0::X_IS_NEGATIVE {
-		x_times_p = - x_times_p;
-	    }
-	    if (-*p + x_times_p).is_zero() {
-                    false
+                p.mul(BigInteger([Parameters0::X[0], 0, 0, 0])).into();
+            if Parameters0::X_IS_NEGATIVE {
+                x_times_p = -x_times_p;
             }
-            else {
-                let mut x2_times_p: GroupAffine<_> =
-		    x_times_p.mul(BigInteger([Parameters0::X[0], 0, 0, 0])).into();
-		if Parameters0::X_IS_NEGATIVE {
-		    x2_times_p = -x2_times_p;
-		}
+            if (-*p + x_times_p).is_zero() {
+                false
+            } else {
+                let mut x2_times_p: GroupAffine<_> = x_times_p
+                    .mul(BigInteger([Parameters0::X[0], 0, 0, 0]))
+                    .into();
+                if Parameters0::X_IS_NEGATIVE {
+                    x2_times_p = -x2_times_p;
+                }
                 (x2_times_p + sigma_p).is_zero()
             }
         }

--- a/bls12_381/src/curves/g1.rs
+++ b/bls12_381/src/curves/g1.rs
@@ -45,15 +45,23 @@ impl SWModelParameters for Parameters {
     }
 
     fn is_in_correct_subgroup_assuming_on_curve(p: &GroupAffine<Parameters>) -> bool {
-        // r = (u⁴ - u² + 1) = u² * (u²-1) + 1 = u² * lambda + 1
-        // [r]P = 0 iff [u²] sigma(P) + P = 0
-        let sigma_p = sigma(p);
-        let mut mul_sigma_p: GroupAffine<_> =
-            sigma_p.mul(BigInteger([Parameters0::X[0], 0, 0, 0])).into();
-        mul_sigma_p = mul_sigma_p
-            .mul(BigInteger([Parameters0::X[0], 0, 0, 0]))
-            .into();
-        (mul_sigma_p + *p).is_zero()
+        // Check that sigma(P) == -[X²]P
+        // if [X]P = P during the computation, return False
+        if p.is_zero() {
+            true
+        }
+        else {
+            let sigma_p = sigma(p);
+            let x_times_p: GroupAffine<_> =
+                p.mul(BigInteger([Parameters0::X[0], 0, 0, 0])).into();
+            if (x_times_p + (-*p)).is_zero() {
+                false
+            }
+            else {
+                let x2_times_p: GroupAffine<_> = x_times_p.mul(BigInteger([Parameters0::X[0], 0, 0, 0])).into();
+                (x2_times_p + sigma_p).is_zero()
+            }
+        }
     }
 }
 
@@ -67,7 +75,7 @@ pub const G1_GENERATOR_X: Fq = field_new!(Fq, "368541675371338701678108831518307
 #[rustfmt::skip]
 pub const G1_GENERATOR_Y: Fq = field_new!(Fq, "1339506544944476473020471379941921221584933875938349620426543736416511423956333506472724655353366534992391756441569");
 
-pub const BETA: Fq = field_new!(Fq,"4002409555221667392624310435006688643935503118305586438271171395842971157480381377015405980053539358417135540939436");
+pub const BETA: Fq = field_new!(Fq,"793479390729215512621379701633421447060886740281060493010456487427281649075476305620758731620350");
 
 pub fn sigma(p: &GroupAffine<Parameters>) -> GroupAffine<Parameters> {
     let mut sigma_p = *p;

--- a/bls12_381/src/curves/g1.rs
+++ b/bls12_381/src/curves/g1.rs
@@ -1,12 +1,15 @@
 use crate::*;
+use ark_ec::bls12::Bls12Parameters;
 use ark_ec::{
     bls12,
     models::{ModelParameters, SWModelParameters},
+    short_weierstrass_jacobian::GroupAffine,
+    AffineCurve,
 };
-use ark_ff::{field_new, Zero};
+use ark_ff::{biginteger::BigInteger256 as BigInteger, field_new, Zero};
 
-pub type G1Affine = bls12::G1Affine<crate::Parameters>;
-pub type G1Projective = bls12::G1Projective<crate::Parameters>;
+pub type G1Affine = bls12::G1Affine<crate::Parameters0>;
+pub type G1Projective = bls12::G1Projective<crate::Parameters0>;
 
 #[derive(Clone, Default, PartialEq, Eq)]
 pub struct Parameters;
@@ -40,6 +43,18 @@ impl SWModelParameters for Parameters {
     fn mul_by_a(_: &Self::BaseField) -> Self::BaseField {
         Self::BaseField::zero()
     }
+
+    fn is_in_correct_subgroup_assuming_on_curve(p: &GroupAffine<Parameters>) -> bool {
+        // r = (u⁴ - u² + 1) = u² * (u²-1) + 1 = u² * lambda + 1
+        // [r]P = 0 iff [u²] sigma(P) + P = 0
+        let sigma_p = sigma(p);
+        let mut mul_sigma_p: GroupAffine<_> =
+            sigma_p.mul(BigInteger([Parameters0::X[0], 0, 0, 0])).into();
+        mul_sigma_p = mul_sigma_p
+            .mul(BigInteger([Parameters0::X[0], 0, 0, 0]))
+            .into();
+        (mul_sigma_p + *p).is_zero()
+    }
 }
 
 /// G1_GENERATOR_X =
@@ -51,3 +66,11 @@ pub const G1_GENERATOR_X: Fq = field_new!(Fq, "368541675371338701678108831518307
 /// 1339506544944476473020471379941921221584933875938349620426543736416511423956333506472724655353366534992391756441569
 #[rustfmt::skip]
 pub const G1_GENERATOR_Y: Fq = field_new!(Fq, "1339506544944476473020471379941921221584933875938349620426543736416511423956333506472724655353366534992391756441569");
+
+pub const BETA: Fq = field_new!(Fq,"4002409555221667392624310435006688643935503118305586438271171395842971157480381377015405980053539358417135540939436");
+
+pub fn sigma(p: &GroupAffine<Parameters>) -> GroupAffine<Parameters> {
+    let mut sigma_p = *p;
+    sigma_p.x *= BETA;
+    sigma_p
+}

--- a/bls12_381/src/curves/g1.rs
+++ b/bls12_381/src/curves/g1.rs
@@ -46,7 +46,7 @@ impl SWModelParameters for Parameters {
     fn is_in_correct_subgroup_assuming_on_curve(p: &GroupAffine<Parameters>) -> bool {
         // Algorithm from https://eprint.iacr.org/2021/1130,
         // see Section 6.
-	// Check that sigma(P) == -[X²]P
+        // Check that sigma(P) == -[X²]P
         // if [X]P = P during the computation, return False
         if p.is_zero() {
             true

--- a/bls12_381/src/curves/g1.rs
+++ b/bls12_381/src/curves/g1.rs
@@ -44,7 +44,9 @@ impl SWModelParameters for Parameters {
     }
 
     fn is_in_correct_subgroup_assuming_on_curve(p: &GroupAffine<Parameters>) -> bool {
-        // Check that sigma(P) == -[X²]P
+        // Algorithm from https://eprint.iacr.org/2021/1130,
+        // see Section 6.
+	// Check that sigma(P) == -[X²]P
         // if [X]P = P during the computation, return False
         if p.is_zero() {
             true

--- a/bls12_381/src/curves/g1.rs
+++ b/bls12_381/src/curves/g1.rs
@@ -59,8 +59,8 @@ impl SWModelParameters for Parameters {
             if x_times_p.add_mixed(p).is_zero() {
                 false
             } else {
-		let sigma_p = sigma(p);
-		// TODO
+                let sigma_p = sigma(p);
+                // TODO
                 let mut x2_times_p = x_times_p.mul(BigInteger([crate::Parameters::X[0], 0, 0, 0]));
                 if crate::Parameters::X_IS_NEGATIVE {
                     x2_times_p = -x2_times_p;

--- a/bls12_381/src/curves/g1.rs
+++ b/bls12_381/src/curves/g1.rs
@@ -8,8 +8,8 @@ use ark_ec::{
 };
 use ark_ff::{biginteger::BigInteger256 as BigInteger, field_new, Zero};
 
-pub type G1Affine = bls12::G1Affine<crate::Parameters0>;
-pub type G1Projective = bls12::G1Projective<crate::Parameters0>;
+pub type G1Affine = bls12::G1Affine<crate::Parameters>;
+pub type G1Projective = bls12::G1Projective<crate::Parameters>;
 
 #[derive(Clone, Default, PartialEq, Eq)]
 pub struct Parameters;
@@ -52,17 +52,17 @@ impl SWModelParameters for Parameters {
         } else {
             let sigma_p = sigma(p);
             let mut x_times_p: GroupAffine<_> =
-                p.mul(BigInteger([Parameters0::X[0], 0, 0, 0])).into();
-            if Parameters0::X_IS_NEGATIVE {
+                p.mul(BigInteger([crate::Parameters::X[0], 0, 0, 0])).into();
+            if crate::Parameters::X_IS_NEGATIVE {
                 x_times_p = -x_times_p;
             }
             if (-*p + x_times_p).is_zero() {
                 false
             } else {
                 let mut x2_times_p: GroupAffine<_> = x_times_p
-                    .mul(BigInteger([Parameters0::X[0], 0, 0, 0]))
+                    .mul(BigInteger([crate::Parameters::X[0], 0, 0, 0]))
                     .into();
-                if Parameters0::X_IS_NEGATIVE {
+                if crate::Parameters::X_IS_NEGATIVE {
                     x2_times_p = -x2_times_p;
                 }
                 (x2_times_p + sigma_p).is_zero()
@@ -81,9 +81,13 @@ pub const G1_GENERATOR_X: Fq = field_new!(Fq, "368541675371338701678108831518307
 #[rustfmt::skip]
 pub const G1_GENERATOR_Y: Fq = field_new!(Fq, "1339506544944476473020471379941921221584933875938349620426543736416511423956333506472724655353366534992391756441569");
 
+// BETA is a third root of unity, meaning that BETA²+BETA+1 = 0
 pub const BETA: Fq = field_new!(Fq,"793479390729215512621379701633421447060886740281060493010456487427281649075476305620758731620350");
 
 pub fn sigma(p: &GroupAffine<Parameters>) -> GroupAffine<Parameters> {
+    // Endomorphism of the curve
+    // sigma(x,y) = (BETA*x, y) where BETA is a third root of unity of
+    // Fq
     let mut sigma_p = *p;
     sigma_p.x *= BETA;
     sigma_p

--- a/bls12_381/src/curves/g1.rs
+++ b/bls12_381/src/curves/g1.rs
@@ -1,7 +1,7 @@
 use crate::*;
-use ark_ec::bls12::Bls12Parameters;
 use ark_ec::{
     bls12,
+    bls12::Bls12Parameters,
     models::{ModelParameters, SWModelParameters},
     short_weierstrass_jacobian::GroupAffine,
     AffineCurve,

--- a/bls12_381/src/curves/g1.rs
+++ b/bls12_381/src/curves/g1.rs
@@ -51,7 +51,6 @@ impl SWModelParameters for Parameters {
         if p.is_zero() {
             true
         } else {
-            let sigma_p = sigma(p);
             // TODO
             let mut x_times_p = p.mul(BigInteger([crate::Parameters::X[0], 0, 0, 0]));
             if crate::Parameters::X_IS_NEGATIVE {
@@ -60,7 +59,8 @@ impl SWModelParameters for Parameters {
             if x_times_p.add_mixed(p).is_zero() {
                 false
             } else {
-                // TODO
+		let sigma_p = sigma(p);
+		// TODO
                 let mut x2_times_p = x_times_p.mul(BigInteger([crate::Parameters::X[0], 0, 0, 0]));
                 if crate::Parameters::X_IS_NEGATIVE {
                     x2_times_p = -x2_times_p;

--- a/bls12_381/src/curves/g1.rs
+++ b/bls12_381/src/curves/g1.rs
@@ -52,13 +52,21 @@ impl SWModelParameters for Parameters {
         }
         else {
             let sigma_p = sigma(p);
-            let x_times_p: GroupAffine<_> =
-                p.mul(BigInteger([Parameters0::X[0], 0, 0, 0])).into();
-            if (x_times_p + (-*p)).is_zero() {
-                false
+            let mut x_times_p: GroupAffine<_> =
+                p.mul(BigInteger([Parameters0::X[0], 0, 0,
+				  0])).into();
+	    if Parameters0::X_IS_NEGATIVE {
+		x_times_p = - x_times_p;
+	    }
+	    if (-*p + x_times_p).is_zero() {
+                    false
             }
             else {
-                let x2_times_p: GroupAffine<_> = x_times_p.mul(BigInteger([Parameters0::X[0], 0, 0, 0])).into();
+                let mut x2_times_p: GroupAffine<_> =
+		    x_times_p.mul(BigInteger([Parameters0::X[0], 0, 0, 0])).into();
+		if Parameters0::X_IS_NEGATIVE {
+		    x2_times_p = -x2_times_p;
+		}
                 (x2_times_p + sigma_p).is_zero()
             }
         }

--- a/bls12_381/src/curves/g1.rs
+++ b/bls12_381/src/curves/g1.rs
@@ -4,9 +4,11 @@ use ark_ec::{
     bls12,
     models::{ModelParameters, SWModelParameters},
     short_weierstrass_jacobian::GroupAffine,
-    AffineCurve, ProjectiveCurve,
+    AffineCurve,
 };
-use ark_ff::{biginteger::BigInteger256 as BigInteger, field_new, Zero};
+use ark_ff::{biginteger::BigInteger256, field_new, Zero};
+use ark_std::ops::Neg;
+
 pub type G1Affine = bls12::G1Affine<crate::Parameters>;
 pub type G1Projective = bls12::G1Projective<crate::Parameters>;
 
@@ -44,30 +46,17 @@ impl SWModelParameters for Parameters {
     }
 
     fn is_in_correct_subgroup_assuming_on_curve(p: &GroupAffine<Parameters>) -> bool {
-        // Algorithm from https://eprint.iacr.org/2021/1130,
-        // see Section 6.
-        // Check that sigma(P) == -[X²]P
-        // if [X]P = P during the computation, return False
-        if p.is_zero() {
-            true
-        } else {
-            // TODO
-            let mut x_times_p = p.mul(BigInteger([crate::Parameters::X[0], 0, 0, 0]));
-            if crate::Parameters::X_IS_NEGATIVE {
-                x_times_p = -x_times_p;
-            }
-            if x_times_p.add_mixed(p).is_zero() {
-                false
-            } else {
-                let sigma_p = sigma(p);
-                // TODO
-                let mut x2_times_p = x_times_p.mul(BigInteger([crate::Parameters::X[0], 0, 0, 0]));
-                if crate::Parameters::X_IS_NEGATIVE {
-                    x2_times_p = -x2_times_p;
-                }
-                x2_times_p.add_mixed(&sigma_p).is_zero()
-            }
-        }
+        // Algorithm from Section 6 of https://eprint.iacr.org/2021/1130.
+        //
+        // Check that endomorphism_p(P) == -[X^2]P
+
+        let x = Self::ScalarField::from(BigInteger256::new([crate::Parameters::X[0], 0, 0, 0]));
+        let x_squared = x * &x;
+
+        let x_times_p = p.mul(x_squared).neg();
+        let endomorphism_p = endomorphism(p);
+
+        x_times_p.eq(&endomorphism_p)
     }
 }
 
@@ -81,14 +70,13 @@ pub const G1_GENERATOR_X: Fq = field_new!(Fq, "368541675371338701678108831518307
 #[rustfmt::skip]
 pub const G1_GENERATOR_Y: Fq = field_new!(Fq, "1339506544944476473020471379941921221584933875938349620426543736416511423956333506472724655353366534992391756441569");
 
-// BETA is a third root of unity, meaning that BETA²+BETA+1 = 0
-pub const BETA: Fq = field_new!(Fq,"793479390729215512621379701633421447060886740281060493010456487427281649075476305620758731620350");
+/// BETA is a non-trivial cubic root of unity in Fq.
+pub const BETA: Fq = field_new!(Fq, "793479390729215512621379701633421447060886740281060493010456487427281649075476305620758731620350");
 
-pub fn sigma(p: &GroupAffine<Parameters>) -> GroupAffine<Parameters> {
-    // Endomorphism of the curve
-    // sigma(x,y) = (BETA*x, y) where BETA is a third root of unity of
-    // Fq
-    let mut sigma_p = *p;
-    sigma_p.x *= BETA;
-    sigma_p
+pub fn endomorphism(p: &GroupAffine<Parameters>) -> GroupAffine<Parameters> {
+    // Endomorphism of the points on the curve.
+    // endomorphism_p(x,y) = (BETA * x, y) where BETA is a non-trivial cubic root of unity in Fq.
+    let mut res = (*p).clone();
+    res.x *= BETA;
+    res
 }

--- a/bls12_381/src/curves/g1.rs
+++ b/bls12_381/src/curves/g1.rs
@@ -4,10 +4,9 @@ use ark_ec::{
     bls12,
     models::{ModelParameters, SWModelParameters},
     short_weierstrass_jacobian::GroupAffine,
-    AffineCurve,
+    AffineCurve, ProjectiveCurve,
 };
 use ark_ff::{biginteger::BigInteger256 as BigInteger, field_new, Zero};
-
 pub type G1Affine = bls12::G1Affine<crate::Parameters>;
 pub type G1Projective = bls12::G1Projective<crate::Parameters>;
 
@@ -51,21 +50,21 @@ impl SWModelParameters for Parameters {
             true
         } else {
             let sigma_p = sigma(p);
-            let mut x_times_p: GroupAffine<_> =
-                p.mul(BigInteger([crate::Parameters::X[0], 0, 0, 0])).into();
+	    // TODO
+            let mut x_times_p =
+                p.mul(BigInteger([crate::Parameters::X[0], 0, 0, 0]));
             if crate::Parameters::X_IS_NEGATIVE {
                 x_times_p = -x_times_p;
             }
-            if (-*p + x_times_p).is_zero() {
+            if x_times_p.add_mixed(p).is_zero() {
                 false
             } else {
-                let mut x2_times_p: GroupAffine<_> = x_times_p
-                    .mul(BigInteger([crate::Parameters::X[0], 0, 0, 0]))
-                    .into();
+		// TODO
+                let mut x2_times_p = x_times_p.mul(BigInteger([crate::Parameters::X[0], 0, 0, 0]));
                 if crate::Parameters::X_IS_NEGATIVE {
                     x2_times_p = -x2_times_p;
                 }
-                (x2_times_p + sigma_p).is_zero()
+                x2_times_p.add_mixed(&sigma_p).is_zero()
             }
         }
     }

--- a/bls12_381/src/curves/g2.rs
+++ b/bls12_381/src/curves/g2.rs
@@ -120,12 +120,12 @@ pub const P_POWER_ENDOMORPHISM_COEFF_1: Fq2 = field_new!(
 
 pub fn p_power_endomorphism(p: &GroupAffine<Parameters>) -> GroupAffine<Parameters> {
     // The p-power endomorphism for G2 is defined as follows:
-    // 1. Note that G2 is defined on curve E': y^2 = x^3 + 4(u+1). To map a point (x, y) in E' to (u, v) in E,
-    //    one set u = x / ((u+1) ^ (1/3)), v = y / ((u+1) ^ (1/2)), because E: y^2 = x^3 + 4.
-    // 2. Apply the Frobenius endomorphism (u, v) => (u', v'), another point on curve E,
-    //    where u' = u^p, v' = v^p.
+    // 1. Note that G2 is defined on curve E': y^2 = x^3 + 4(u+1). To map a point (x, y) in E' to (s, t) in E,
+    //    one set s = x / ((u+1) ^ (1/3)), t = y / ((u+1) ^ (1/2)), because E: y^2 = x^3 + 4.
+    // 2. Apply the Frobenius endomorphism (s, t) => (s', t'), another point on curve E,
+    //    where s' = s^p, t' = t^p.
     // 3. Map the point from E back to E'; that is,
-    //    one set x' = u' * ((u+1) ^ (1/3)), y' = v' * ((u+1) ^ (1/2)).
+    //    one set x' = s' * ((u+1) ^ (1/3)), y' = t' * ((u+1) ^ (1/2)).
     //
     // To sum up, it maps
     // (x,y) -> (x^p / ((u+1)^((p-1)/3)), y^p / ((u+1)^((p-1)/2)))

--- a/bls12_381/src/curves/g2.rs
+++ b/bls12_381/src/curves/g2.rs
@@ -4,6 +4,7 @@ use ark_ec::{
     bls12,
     models::{ModelParameters, SWModelParameters},
     short_weierstrass_jacobian::GroupAffine,
+    short_weierstrass_jacobian::GroupProjective,
     AffineCurve,
 };
 use ark_ff::{biginteger::BigInteger256 as BigInteger, field_new, Field, Zero};
@@ -57,12 +58,12 @@ impl SWModelParameters for Parameters {
 
     fn is_in_correct_subgroup_assuming_on_curve(point: &GroupAffine<Parameters>) -> bool {
         // check that [p]P = [X]P
-        let mut x_times_point: GroupAffine<_> =
-            point.mul(BigInteger([crate::Parameters::X[0], 0, 0, 0])).into();
+	// TODO
+        let mut x_times_point = point.mul(BigInteger([crate::Parameters::X[0], 0, 0, 0]));
         if crate::Parameters::X_IS_NEGATIVE {
             x_times_point = -x_times_point;
         }
-        let p_times_point = psi(point);
+        let p_times_point:GroupProjective<Parameters> = psi(point).into();
         (-x_times_point + p_times_point).is_zero()
     }
 }

--- a/bls12_381/src/curves/g2.rs
+++ b/bls12_381/src/curves/g2.rs
@@ -58,7 +58,7 @@ impl SWModelParameters for Parameters {
     fn is_in_correct_subgroup_assuming_on_curve(point: &GroupAffine<Parameters>) -> bool {
         // Algorithm from https://eprint.iacr.org/2021/1130,
         // see Section 4.
-	// Checks that [p]P = [X]P
+        // Checks that [p]P = [X]P
         // TODO
         let mut x_times_point = point.mul(BigInteger([crate::Parameters::X[0], 0, 0, 0]));
 

--- a/bls12_381/src/curves/g2.rs
+++ b/bls12_381/src/curves/g2.rs
@@ -57,9 +57,10 @@ impl SWModelParameters for Parameters {
 
     fn is_in_correct_subgroup_assuming_on_curve(point: &GroupAffine<Parameters>) -> bool {
         // check that [p]P = [X]P
-        let mut x_times_point: GroupAffine<_> = point.mul(BigInteger([Parameters0::X[0], 0, 0, 0])).into();
+        let mut x_times_point: GroupAffine<_> =
+            point.mul(BigInteger([Parameters0::X[0], 0, 0, 0])).into();
         if Parameters0::X_IS_NEGATIVE {
-            x_times_point = - x_times_point;
+            x_times_point = -x_times_point;
         }
         let p_times_point = psi(point);
         (-x_times_point + p_times_point).is_zero()
@@ -109,7 +110,7 @@ pub const PSI_Y: Fq2 = field_new!(
        "1028732146235106349975324479215795277384839936929757896155643118032610843298655225875571310552543014690878354869257")
 );
 pub fn psi(p: &GroupAffine<Parameters>) -> GroupAffine<Parameters> {
-    // frobenius endomorphism on the G1 curve, conjugated with the sextic twist  
+    // frobenius endomorphism on the G1 curve, conjugated with the sextic twist
     let mut psi_p = *p;
     psi_p.x.frobenius_map(1);
     psi_p.y.frobenius_map(1);

--- a/bls12_381/src/curves/g2.rs
+++ b/bls12_381/src/curves/g2.rs
@@ -97,7 +97,7 @@ pub const G2_GENERATOR_Y_C0: Fq = field_new!(Fq, "198515060228729193556805452117
 #[rustfmt::skip]
 pub const G2_GENERATOR_Y_C1: Fq = field_new!(Fq, "927553665492332455747201965776037880757740193453592970025027978793976877002675564980949289727957565575433344219582");
 
-// psi(x,y) = (x^p * PSI_X, y^p * PSI_Y) is the Frobenius composed
+// psi(x,y) = (x**p * PSI_X, y**p * PSI_Y) is the Frobenius composed
 // with the quadratic twist and its inverse
 
 // PSI_X = 1/(u+1)**((p-1)//3) where u is the generator of Fp² with u²=-1
@@ -124,7 +124,7 @@ pub const PSI_Y: Fq2 = field_new!(
 pub fn psi(p: &GroupAffine<Parameters>) -> GroupAffine<Parameters> {
     // Psi is an endomorphism of the curve defined with the sextic
     // twists and the frobenius endomorphism on the G1 curve
-    // (x,y) -> (x^p / (u+1)**((p-1)//3), y^p / (u+1)**((p-1)//2))
+    // (x,y) -> (x**p / (u+1)**((p-1)//3), y**p / (u+1)**((p-1)//2))
     // where u is the generator of Fp² with u²=-1
     let mut psi_p = *p;
     psi_p.x.frobenius_map(1);

--- a/bls12_381/src/curves/g2.rs
+++ b/bls12_381/src/curves/g2.rs
@@ -1,12 +1,15 @@
 use crate::*;
+use ark_ec::bls12::Bls12Parameters;
 use ark_ec::{
     bls12,
     models::{ModelParameters, SWModelParameters},
+    short_weierstrass_jacobian::GroupAffine,
+    AffineCurve,
 };
-use ark_ff::{field_new, Zero};
+use ark_ff::{biginteger::BigInteger256 as BigInteger, field_new, Field, Zero};
 
-pub type G2Affine = bls12::G2Affine<crate::Parameters>;
-pub type G2Projective = bls12::G2Projective<crate::Parameters>;
+pub type G2Affine = bls12::G2Affine<crate::Parameters0>;
+pub type G2Projective = bls12::G2Projective<crate::Parameters0>;
 
 #[derive(Clone, Default, PartialEq, Eq)]
 pub struct Parameters;
@@ -51,6 +54,17 @@ impl SWModelParameters for Parameters {
     fn mul_by_a(_: &Self::BaseField) -> Self::BaseField {
         Self::BaseField::zero()
     }
+
+    fn is_in_correct_subgroup_assuming_on_curve(p: &GroupAffine<Parameters>) -> bool {
+        let psi2_p = psi2(p);
+        let psi3_p = psi3(p);
+        let mut mul_psi3_p: GroupAffine<_> =
+            psi3_p.mul(BigInteger([Parameters0::X[0], 0, 0, 0])).into();
+        if Parameters0::X_IS_NEGATIVE {
+            mul_psi3_p = -mul_psi3_p;
+        }
+        (mul_psi3_p + (-psi2_p) + *p).is_zero()
+    }
 }
 
 pub const G2_GENERATOR_X: Fq2 = field_new!(Fq2, G2_GENERATOR_X_C0, G2_GENERATOR_X_C1);
@@ -75,3 +89,61 @@ pub const G2_GENERATOR_Y_C0: Fq = field_new!(Fq, "198515060228729193556805452117
 /// 927553665492332455747201965776037880757740193453592970025027978793976877002675564980949289727957565575433344219582
 #[rustfmt::skip]
 pub const G2_GENERATOR_Y_C1: Fq = field_new!(Fq, "927553665492332455747201965776037880757740193453592970025027978793976877002675564980949289727957565575433344219582");
+
+// psi(x,y) = (x^p * PSI_X, y^p * PSI_Y) is the Frobenius composed
+// with the quadratic twist and its inverse
+pub const PSI_X:Fq2 = field_new!(
+    Fq2,
+    FQ_ZERO,
+    field_new!(
+	Fq,
+	"4002409555221667392624310435006688643935503118305586438271171395842971157480381377015405980053539358417135540939437"
+    )
+);
+pub const PSI_Y: Fq2 = field_new!(
+    Fq2,
+    field_new!(
+	Fq,
+	"2973677408986561043442465346520108879172042883009249989176415018091420807192182638567116318576472649347015917690530"),
+    field_new!(
+	Fq,
+	"1028732146235106349975324479215795277384839936929757896155643118032610843298655225875571310552543014690878354869257")
+);
+pub fn psi(p: &GroupAffine<Parameters>) -> GroupAffine<Parameters> {
+    let mut psi_p = *p;
+    psi_p.x.frobenius_map(1);
+    psi_p.y.frobenius_map(1);
+    // psi_p.x *= PSI_X but PSI_X.c0 = 0
+    let tmp = psi_p.x;
+    psi_p.x.c0 = -tmp.c1 * PSI_X.c1;
+    psi_p.x.c1 = tmp.c0 * PSI_X.c1;
+    psi_p.y *= PSI_Y;
+    psi_p
+}
+
+// psi2(x,y) = psi²(x,y) = (x*PSI2_X, -y) where PSI2_X = PSI_X^{p+1}
+// is in Fq and PSI_Y^{p+1} = -1.
+pub const PSI2_X:Fq =
+    field_new!(
+	Fq,
+	"4002409555221667392624310435006688643935503118305586438271171395842971157480381377015405980053539358417135540939436"
+    );
+pub fn psi2(p: &GroupAffine<Parameters>) -> GroupAffine<Parameters> {
+    let mut psi2_p = -*p;
+    psi2_p.x.mul_assign_by_basefield(&PSI2_X);
+    psi2_p
+}
+
+// psi3(x,y) = psi³(x,y) = (x^p*(-u), -y^p * PSI_Y)
+// (PSI2_X^p * PSI_X = -u and (-1)^p = -1)
+pub fn psi3(p: &GroupAffine<Parameters>) -> GroupAffine<Parameters> {
+    let mut psi3_p = p.clone();
+    psi3_p.x.frobenius_map(1);
+    psi3_p.y.frobenius_map(1);
+    // psi3_p.x *= (-u)
+    let tmp = psi3_p.x;
+    psi3_p.x.c1 = -tmp.c0;
+    psi3_p.x.c0 = tmp.c1; // * (-u²) but u² = -1
+    psi3_p.y *= PSI_Y;
+    -psi3_p
+}

--- a/bls12_381/src/curves/g2.rs
+++ b/bls12_381/src/curves/g2.rs
@@ -8,8 +8,8 @@ use ark_ec::{
 };
 use ark_ff::{biginteger::BigInteger256 as BigInteger, field_new, Field, Zero};
 
-pub type G2Affine = bls12::G2Affine<crate::Parameters0>;
-pub type G2Projective = bls12::G2Projective<crate::Parameters0>;
+pub type G2Affine = bls12::G2Affine<crate::Parameters>;
+pub type G2Projective = bls12::G2Projective<crate::Parameters>;
 
 #[derive(Clone, Default, PartialEq, Eq)]
 pub struct Parameters;
@@ -58,8 +58,8 @@ impl SWModelParameters for Parameters {
     fn is_in_correct_subgroup_assuming_on_curve(point: &GroupAffine<Parameters>) -> bool {
         // check that [p]P = [X]P
         let mut x_times_point: GroupAffine<_> =
-            point.mul(BigInteger([Parameters0::X[0], 0, 0, 0])).into();
-        if Parameters0::X_IS_NEGATIVE {
+            point.mul(BigInteger([crate::Parameters::X[0], 0, 0, 0])).into();
+        if crate::Parameters::X_IS_NEGATIVE {
             x_times_point = -x_times_point;
         }
         let p_times_point = psi(point);

--- a/bls12_381/src/curves/g2.rs
+++ b/bls12_381/src/curves/g2.rs
@@ -97,6 +97,8 @@ pub const G2_GENERATOR_Y_C1: Fq = field_new!(Fq, "927553665492332455747201965776
 
 // psi(x,y) = (x^p * PSI_X, y^p * PSI_Y) is the Frobenius composed
 // with the quadratic twist and its inverse
+
+// PSI_X = 1/(u+1)**((p-1)//3) where u is the generator of Fp² with u²=-1
 pub const PSI_X:Fq2 = field_new!(
     Fq2,
     FQ_ZERO,
@@ -105,6 +107,8 @@ pub const PSI_X:Fq2 = field_new!(
        "4002409555221667392624310435006688643935503118305586438271171395842971157480381377015405980053539358417135540939437"
     )
 );
+
+// PSI_Y = 1/(u+1)**((p-1)//2) where u is the generator of Fp² with u²=-1
 pub const PSI_Y: Fq2 = field_new!(
     Fq2,
     field_new!(
@@ -114,8 +118,12 @@ pub const PSI_Y: Fq2 = field_new!(
        Fq,
        "1028732146235106349975324479215795277384839936929757896155643118032610843298655225875571310552543014690878354869257")
 );
+
 pub fn psi(p: &GroupAffine<Parameters>) -> GroupAffine<Parameters> {
-    // frobenius endomorphism on the G1 curve, conjugated with the sextic twist
+    // Psi is an endomorphism of the curve defined with the sextic
+    // twists and the frobenius endomorphism on the G1 curve
+    // (x,y) -> (x^p / (u+1)**((p-1)//3), y^p / (u+1)**((p-1)//2))
+    // where u is the generator of Fp² with u²=-1
     let mut psi_p = *p;
     psi_p.x.frobenius_map(1);
     psi_p.y.frobenius_map(1);

--- a/bls12_381/src/curves/g2.rs
+++ b/bls12_381/src/curves/g2.rs
@@ -128,7 +128,7 @@ pub fn p_power_endomorphism(p: &GroupAffine<Parameters>) -> GroupAffine<Paramete
     //    one set x' = u' * ((u+1) ^ (1/3)), y' = v' * ((u+1) ^ (1/2)).
     //
     // To sum up, it maps
-    // (x,y) -> (x^p / ((u+1)^((p-1)/3)), y^p / ((u+1)**((p-1)/2)))
+    // (x,y) -> (x^p / ((u+1)^((p-1)/3)), y^p / ((u+1)^((p-1)/2)))
     // as implemented in the code as follows.
 
     let mut res = *p;

--- a/bls12_381/src/curves/g2.rs
+++ b/bls12_381/src/curves/g2.rs
@@ -57,11 +57,10 @@ impl SWModelParameters for Parameters {
 
     fn is_in_correct_subgroup_assuming_on_curve(point: &GroupAffine<Parameters>) -> bool {
         // check that [p]P = [X]P
-	// TODO
-        let mut x_times_point =
-	    point.mul(BigInteger([crate::Parameters::X[0], 0, 0, 0]));
+        // TODO
+        let mut x_times_point = point.mul(BigInteger([crate::Parameters::X[0], 0, 0, 0]));
 
-	// The check is `p_times_point - x_times_point == 0`?
+        // The check is `p_times_point - x_times_point == 0`?
         // If `x` is negative, then the LHS becomes `p_times_point + x_times_point`.
         // If `x` is positive, then it remains `p_times_point - x_times_point`.
         // So, we negate if `x` is positive, and add the result.

--- a/bls12_381/src/curves/g2.rs
+++ b/bls12_381/src/curves/g2.rs
@@ -56,7 +56,9 @@ impl SWModelParameters for Parameters {
     }
 
     fn is_in_correct_subgroup_assuming_on_curve(point: &GroupAffine<Parameters>) -> bool {
-        // check that [p]P = [X]P
+        // Algorithm from https://eprint.iacr.org/2021/1130,
+        // see Section 4.
+	// Checks that [p]P = [X]P
         // TODO
         let mut x_times_point = point.mul(BigInteger([crate::Parameters::X[0], 0, 0, 0]));
 

--- a/bls12_381/src/curves/mod.rs
+++ b/bls12_381/src/curves/mod.rs
@@ -13,11 +13,11 @@ pub use self::{
     g2::{G2Affine, G2Projective},
 };
 
-pub type Bls12_381 = Bls12<Parameters0>;
+pub type Bls12_381 = Bls12<Parameters>;
 
-pub struct Parameters0;
+pub struct Parameters;
 
-impl Bls12Parameters for Parameters0 {
+impl Bls12Parameters for Parameters {
     const X: &'static [u64] = &[0xd201000000010000];
     const X_IS_NEGATIVE: bool = true;
     const TWIST_TYPE: TwistType = TwistType::M;

--- a/bls12_381/src/curves/mod.rs
+++ b/bls12_381/src/curves/mod.rs
@@ -13,11 +13,11 @@ pub use self::{
     g2::{G2Affine, G2Projective},
 };
 
-pub type Bls12_381 = Bls12<Parameters>;
+pub type Bls12_381 = Bls12<Parameters0>;
 
-pub struct Parameters;
+pub struct Parameters0;
 
-impl Bls12Parameters for Parameters {
+impl Bls12Parameters for Parameters0 {
     const X: &'static [u64] = &[0xd201000000010000];
     const X_IS_NEGATIVE: bool = true;
     const TWIST_TYPE: TwistType = TwistType::M;

--- a/bls12_381/src/curves/tests.rs
+++ b/bls12_381/src/curves/tests.rs
@@ -121,18 +121,6 @@ fn test_g1_generator_raw() {
 }
 
 #[test]
-fn test_psi() {
-    let generator = G2Affine::prime_subgroup_generator();
-    let mut psi_generator = g2::psi(&generator);
-    psi_generator = g2::psi(&psi_generator);
-    let psi2_generator = g2::psi2(&generator);
-    assert_eq!(psi_generator, psi2_generator);
-    psi_generator = g2::psi(&psi_generator);
-    let psi3_generator = g2::psi3(&generator);
-    assert_eq!(psi3_generator, psi_generator);
-}
-
-#[test]
 fn test_sigma() {
     let generator = G1Affine::prime_subgroup_generator();
     let mut sigma_generator = g1::sigma(&generator);

--- a/bls12_381/src/curves/tests.rs
+++ b/bls12_381/src/curves/tests.rs
@@ -148,3 +148,26 @@ fn test_g1_subgroup_non_membership_via_endomorphism() {
         }
     }
 }
+
+#[test]
+fn test_g2_subgroup_membership_via_endomorphism() {
+    let mut rng = test_rng();
+    let generator = G2Projective::rand(&mut rng).into_affine();
+    assert!(generator.is_in_correct_subgroup_assuming_on_curve());
+}
+
+#[test]
+fn test_g2_subgroup_non_membership_via_endomorphism() {
+    let mut rng = test_rng();
+    loop {
+        let x = Fq2::rand(&mut rng);
+        let greatest = rng.gen();
+
+        if let Some(p) = G2Affine::get_point_from_x(x, greatest) {
+            if !p.into_projective().mul(Fr::characteristic()).is_zero() {
+                assert!(!p.is_in_correct_subgroup_assuming_on_curve());
+                return;
+            }
+        }
+    }
+}

--- a/bls12_381/src/curves/tests.rs
+++ b/bls12_381/src/curves/tests.rs
@@ -1,5 +1,9 @@
 #![allow(unused_imports)]
-use ark_ec::{models::SWModelParameters, AffineCurve, PairingEngine, ProjectiveCurve};
+use ark_ec::{
+    models::SWModelParameters,
+    short_weierstrass_jacobian::{GroupAffine, GroupProjective},
+    AffineCurve, PairingEngine, ProjectiveCurve,
+};
 use ark_ff::{
     fields::{Field, FpParameters, PrimeField, SquareRootField},
     One, Zero,
@@ -114,4 +118,25 @@ fn test_g1_generator_raw() {
         i += 1;
         x.add_assign(&Fq::one());
     }
+}
+
+#[test]
+fn test_psi() {
+    let generator = G2Affine::prime_subgroup_generator();
+    let mut psi_generator = g2::psi(&generator);
+    psi_generator = g2::psi(&psi_generator);
+    let psi2_generator = g2::psi2(&generator);
+    assert_eq!(psi_generator, psi2_generator);
+    psi_generator = g2::psi(&psi_generator);
+    let psi3_generator = g2::psi3(&generator);
+    assert_eq!(psi3_generator, psi_generator);
+}
+
+#[test]
+fn test_sigma() {
+    let generator = G1Affine::prime_subgroup_generator();
+    let mut sigma_generator = g1::sigma(&generator);
+    sigma_generator = g1::sigma(&sigma_generator);
+    sigma_generator = g1::sigma(&sigma_generator);
+    assert_eq!(sigma_generator, generator);
 }

--- a/bls12_381/src/curves/tests.rs
+++ b/bls12_381/src/curves/tests.rs
@@ -119,6 +119,11 @@ fn test_g1_generator_raw() {
 }
 
 #[test]
+fn test_g1_endomorphism_beta() {
+    assert!(g1::BETA.pow(&[3u64]).is_one());
+}
+
+#[test]
 fn test_g1_subgroup_membership_via_endomorphism() {
     let mut rng = test_rng();
     let generator = G1Projective::rand(&mut rng).into_affine();

--- a/bls12_381/src/curves/tests.rs
+++ b/bls12_381/src/curves/tests.rs
@@ -4,7 +4,10 @@ use ark_ec::{
     short_weierstrass_jacobian::{GroupAffine, GroupProjective},
     AffineCurve, PairingEngine, ProjectiveCurve,
 };
-use ark_ff::{fields::{Field, FpParameters, PrimeField, SquareRootField}, One, Zero, UniformRand, BitIteratorBE};
+use ark_ff::{
+    fields::{Field, FpParameters, PrimeField, SquareRootField},
+    BitIteratorBE, One, UniformRand, Zero,
+};
 use ark_serialize::CanonicalSerialize;
 use ark_std::rand::Rng;
 use ark_std::test_rng;

--- a/curve-benches/src/macros/ec.rs
+++ b/curve-benches/src/macros/ec.rs
@@ -196,6 +196,32 @@ macro_rules! ec_bench {
             });
         }
 
+        fn deser_uncompressed(b: &mut $crate::bencher::Bencher) {
+            use ark_ec::ProjectiveCurve;
+            use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+            const SAMPLES: usize = 1000;
+
+            let mut rng = ark_std::test_rng();
+
+            let mut num_bytes = 0;
+            let tmp = <$projective>::rand(&mut rng).into_affine();
+            let v: Vec<_> = (0..SAMPLES)
+                .flat_map(|_| {
+                    let mut bytes = Vec::with_capacity(1000);
+                    tmp.serialize_uncompressed(&mut bytes).unwrap();
+                    num_bytes = bytes.len();
+                    bytes
+                })
+                .collect();
+
+            let mut count = 0;
+            b.iter(|| {
+                count = (count + 1) % SAMPLES;
+                let index = count * num_bytes;
+                <$affine>::deserialize_uncompressed(&v[index..(index + num_bytes)]).unwrap()
+            });
+        }
+
         fn msm_131072(b: &mut $crate::bencher::Bencher) {
             use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
             const SAMPLES: usize = 131072;
@@ -224,6 +250,7 @@ macro_rules! ec_bench {
             deser,
             ser_unchecked,
             deser_unchecked,
+            deser_uncompressed,
             msm_131072,
         );
     };


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Implementation of the fast subgroup check for G1 and G2 using the Scott algorithm from eprint 2021/1130.

The Scott's implementation (eprint 2021/1130) is slightly faster than Bowe's implementation:

|Author|G1 subgroup check|G2 subgroup check|
|-|-|-|
|Bowe|50.435ns|68.635ns|
|Scott|42.917ns|60.793ns|


closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
