### PR TITLE
Rename add_nocarry and sub_noborrow to match new BigInteger methods

### DIFF
--- a/bls12_381/src/fields/tests.rs
+++ b/bls12_381/src/fields/tests.rs
@@ -1004,7 +1004,7 @@ fn test_fq_repr_num_bits() {
 }
 
 #[test]
-fn test_fq_repr_sub_noborrow() {
+fn test_fq_repr_sub_ret_borrow() {
     let mut rng = ark_std::test_rng();
 
     let mut t = BigInteger384([
@@ -1015,7 +1015,7 @@ fn test_fq_repr_sub_noborrow() {
         0xad0eb3948a5c34fd,
         0xd56f7b5ab8b5ce8,
     ]);
-    t.sub_noborrow(&BigInteger384([
+    t.sub_ret_borrow(&BigInteger384([
         0xc7867917187ca02b,
         0x5d75679d4911ffef,
         0x8c5b3e48b1a71c15,
@@ -1050,12 +1050,12 @@ fn test_fq_repr_sub_noborrow() {
         assert!(b < c);
 
         let mut csub_ba = c;
-        csub_ba.sub_noborrow(&b);
-        csub_ba.sub_noborrow(&a);
+        csub_ba.sub_ret_borrow(&b);
+        csub_ba.sub_ret_borrow(&a);
 
         let mut csub_ab = c;
-        csub_ab.sub_noborrow(&a);
-        csub_ab.sub_noborrow(&b);
+        csub_ab.sub_ret_borrow(&a);
+        csub_ab.sub_ret_borrow(&b);
 
         assert_eq!(csub_ab, csub_ba);
     }
@@ -1069,7 +1069,7 @@ fn test_fq_repr_sub_noborrow() {
         0x4b1ba7b6434bacd7,
         0x1a0111ea397fe69a,
     ]);
-    qplusone.sub_noborrow(&BigInteger384([
+    qplusone.sub_ret_borrow(&BigInteger384([
         0xb9feffffffffaaac,
         0x1eabfffeb153ffff,
         0x6730d2a0f6b0f624,
@@ -1091,7 +1091,7 @@ fn test_fq_repr_sub_noborrow() {
 }
 
 #[test]
-fn test_fq_repr_add_nocarry() {
+fn test_fq_repr_add_ret_carry() {
     let mut rng = ark_std::test_rng();
 
     let mut t = BigInteger384([
@@ -1102,7 +1102,7 @@ fn test_fq_repr_add_nocarry() {
         0xad0eb3948a5c34fd,
         0xd56f7b5ab8b5ce8,
     ]);
-    t.add_nocarry(&BigInteger384([
+    t.add_ret_carry(&BigInteger384([
         0xc7867917187ca02b,
         0x5d75679d4911ffef,
         0x8c5b3e48b1a71c15,
@@ -1133,28 +1133,28 @@ fn test_fq_repr_add_nocarry() {
         c.0[5] >>= 3;
 
         let mut abc = a;
-        abc.add_nocarry(&b);
-        abc.add_nocarry(&c);
+        abc.add_ret_carry(&b);
+        abc.add_ret_carry(&c);
 
         let mut acb = a;
-        acb.add_nocarry(&c);
-        acb.add_nocarry(&b);
+        acb.add_ret_carry(&c);
+        acb.add_ret_carry(&b);
 
         let mut bac = b;
-        bac.add_nocarry(&a);
-        bac.add_nocarry(&c);
+        bac.add_ret_carry(&a);
+        bac.add_ret_carry(&c);
 
         let mut bca = b;
-        bca.add_nocarry(&c);
-        bca.add_nocarry(&a);
+        bca.add_ret_carry(&c);
+        bca.add_ret_carry(&a);
 
         let mut cab = c;
-        cab.add_nocarry(&a);
-        cab.add_nocarry(&b);
+        cab.add_ret_carry(&a);
+        cab.add_ret_carry(&b);
 
         let mut cba = c;
-        cba.add_nocarry(&b);
-        cba.add_nocarry(&a);
+        cba.add_ret_carry(&b);
+        cba.add_ret_carry(&a);
 
         assert_eq!(abc, acb);
         assert_eq!(abc, bac);
@@ -1172,7 +1172,7 @@ fn test_fq_repr_add_nocarry() {
         0xffffffffffffffff,
         0xffffffffffffffff,
     ]);
-    x.add_nocarry(&BigInteger384::from(1));
+    x.add_ret_carry(&BigInteger384::from(1));
     assert!(x.is_zero());
 }
 

--- a/curve-benches/src/macros/field.rs
+++ b/curve-benches/src/macros/field.rs
@@ -24,8 +24,8 @@ macro_rules! f_bench {
                 // sqrt field stuff
                 sqrt,
                 // prime field stuff
-                repr_add_nocarry,
-                repr_sub_noborrow,
+                repr_add_ret_carry,
+                repr_sub_ret_borrow,
                 repr_num_bits,
                 repr_mul2,
                 repr_div2,
@@ -322,7 +322,7 @@ macro_rules! sqrt {
 #[macro_export]
 macro_rules! prime_field {
     ($f:ident, $f_type:ty, $f_repr:ident, $f_repr_type:ty) => {
-        fn repr_add_nocarry(b: &mut $crate::bencher::Bencher) {
+        fn repr_add_ret_carry(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
             let mut rng = ark_std::test_rng();
@@ -343,13 +343,13 @@ macro_rules! prime_field {
             let mut count = 0;
             b.iter(|| {
                 let mut tmp = v[count].0;
-                n_fold!(tmp, v, add_nocarry, count);
+                n_fold!(tmp, v, add_ret_carry, count);
                 count = (count + 1) % SAMPLES;
                 tmp
             });
         }
 
-        fn repr_sub_noborrow(b: &mut $crate::bencher::Bencher) {
+        fn repr_sub_ret_borrow(b: &mut $crate::bencher::Bencher) {
             const SAMPLES: usize = 1000;
 
             let mut rng = ark_std::test_rng();
@@ -369,7 +369,7 @@ macro_rules! prime_field {
             let mut count = 0;
             b.iter(|| {
                 let mut tmp = v[count].0;
-                n_fold!(tmp, v, sub_noborrow, count);
+                n_fold!(tmp, v, sub_ret_borrow, count);
                 count = (count + 1) % SAMPLES;
                 tmp;
             });


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Renamed methods `add_nocarry` and `sub_noborrow` to match newly named methods for biginteger trait.

closes: #NA

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [X ] Targeted PR against correct branch (master)
- [ X] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ X] Wrote unit tests
- [ X] Updated relevant documentation in the code
- [ X] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [X ] Re-reviewed `Files changed` in the Github PR explorer
