### PR TITLE
Revise the version number of Bandersnatch

### DIFF
--- a/ed_on_bls12_381_bandersnatch/Cargo.toml
+++ b/ed_on_bls12_381_bandersnatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark-ed-on-bls12-381-bandersnatch"
-version = "0.1.0"
+version = "0.3.0"
 authors = [ "zhenfei zhang", "arkworks contributors" ]
 description = "Bandersnatch: a curve defined over the scalar field of the BLS12-381 curve"
 repository = "https://github.com/zhenfeizhang/bandersnatch-rust"


### PR DESCRIPTION
## Description

Other curves in the repo uses the same version number (0.3.0) for simplicity of version control. Therefore, this PR unifies this with respect to the Bandersnatch curve, by changing its version number in `Cargo.toml` to `0.3.0`.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the Github PR explorer

N/A: 
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`