### PR TITLE
Documentation provides incorrect calculation

### DIFF
--- a/bn254/src/fields/fr.rs
+++ b/bn254/src/fields/fr.rs
@@ -34,7 +34,7 @@ impl FpParameters for FrParameters {
 
     const REPR_SHAVE_BITS: u32 = 2;
 
-    /// R = pow(2, 320) % MODULUS
+    /// R = pow(2, 256) % MODULUS
     ///   = 6350874878119819312338956282401532410528162663560392320966563075034087161851
     #[rustfmt::skip]
     const R: BigInteger = BigInteger([


### PR DESCRIPTION
## Description

Value is correct at `6350874878119819312338956282401532410528162663560392320966563075034087161851`, but this is `2^256 mod MODULUS`, not the claimed `2^320 mod MODULUS`

---

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] ~~Wrote unit tests~~ (N/A minor documentation change)
- [x] Updated relevant documentation in the code
- [ ] ~~Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`~~ (N/A minor documentation change)
- [x] Re-reviewed `Files changed` in the Github PR explorer
