### PR TITLE
Fixed curve-bench compile error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pending
 
 - [\#76](https://github.com/arkworks-rs/curves/pull/76) twisted Edwards parameters for bls12-377
+- Fixed curve benches
 
 ### Breaking changes
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,4 @@ debug = true
 ark-ec = { git = "https://github.com/arkworks-rs/algebra" }
 ark-ff = { git = "https://github.com/arkworks-rs/algebra" }
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra" }
+ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra" }

--- a/curve-benches/src/macros/ec.rs
+++ b/curve-benches/src/macros/ec.rs
@@ -234,7 +234,7 @@ macro_rules! ec_bench {
                 .map(|_| Fr::rand(&mut rng).into_repr())
                 .collect();
             b.bench_n(1, |b| {
-                b.iter(|| ark_ec::msm::VariableBaseMSM::multi_scalar_mul(&v, &scalars));
+                b.iter(|| ark_ec::msm::VariableBase::msm(&v, &scalars));
             })
         }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Prior to this change, if you did `cargo bench` in `curve-benches/` you'd get the error for all curves (not just BLS12-381)
```
error[E0433]: failed to resolve: could not find `VariableBaseMSM` in `msm`
  --> curve-benches/benches/bls12_381.rs:16:5
   |
16 |     ec_bench!(G1, G1Affine);
   |     ^^^^^^^^^^^^^^^^^^^^^^^ could not find `VariableBaseMSM` in `msm`
   |
   = note: this error originates in the macro `ec_bench` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This change fixes the compile error.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [X] Targeted PR against correct branch (master)
- [X] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [X] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [X] Re-reviewed `Files changed` in the Github PR explorer
