### PR TITLE
Let `cargo build` work again for the new arkworks-rs algebra 

### DIFF
--- a/bls12_381/src/curves/g1.rs
+++ b/bls12_381/src/curves/g1.rs
@@ -5,7 +5,7 @@ use ark_ec::{
     short_weierstrass::{Affine, SWCurveConfig},
     AffineCurve, ProjectiveCurve,
 };
-use ark_ff::{biginteger::BigInteger256, Field, MontFp, Zero};
+use ark_ff::{Field, MontFp, Zero};
 use ark_std::ops::Neg;
 
 use crate::*;
@@ -50,17 +50,15 @@ impl SWCurveConfig for Parameters {
         //
         // Check that endomorphism_p(P) == -[X^2]P
 
-        let x = BigInteger256::new([crate::Parameters::X[0], 0, 0, 0]);
-
         // An early-out optimization described in Section 6.
         // If uP == P but P != point of infinity, then the point is not in the right
         // subgroup.
-        let x_times_p = p.mul(x);
+        let x_times_p = p.mul_bigint(crate::Parameters::X);
         if x_times_p.eq(p) && !p.infinity {
             return false;
         }
 
-        let minus_x_squared_times_p = x_times_p.mul(x).neg();
+        let minus_x_squared_times_p = x_times_p.mul_bigint(crate::Parameters::X).neg();
         let endomorphism_p = endomorphism(p);
         minus_x_squared_times_p.eq(&endomorphism_p)
     }

--- a/bls12_381/src/curves/g2.rs
+++ b/bls12_381/src/curves/g2.rs
@@ -5,7 +5,7 @@ use ark_ec::{
     short_weierstrass::{Affine, SWCurveConfig},
     AffineCurve,
 };
-use ark_ff::{BigInt, Field, MontFp, Zero};
+use ark_ff::{Field, MontFp, Zero};
 
 use crate::*;
 
@@ -60,7 +60,7 @@ impl SWCurveConfig for Parameters {
         //
         // Checks that [p]P = [X]P
 
-        let mut x_times_point = point.mul(BigInt::new([crate::Parameters::X[0], 0, 0, 0]));
+        let mut x_times_point = point.mul_bigint(crate::Parameters::X);
         if crate::Parameters::X_IS_NEGATIVE {
             x_times_point = -x_times_point;
         }

--- a/bls12_381/src/curves/tests.rs
+++ b/bls12_381/src/curves/tests.rs
@@ -39,7 +39,11 @@ fn test_g1_subgroup_non_membership_via_endomorphism() {
         let greatest = rng.gen();
 
         if let Some(p) = G1Affine::get_point_from_x(x, greatest) {
-            if !p.into_projective().mul(Fr::characteristic()).is_zero() {
+            if !p
+                .into_projective()
+                .mul_bigint(Fr::characteristic())
+                .is_zero()
+            {
                 assert!(!p.is_in_correct_subgroup_assuming_on_curve());
                 return;
             }
@@ -62,7 +66,11 @@ fn test_g2_subgroup_non_membership_via_endomorphism() {
         let greatest = rng.gen();
 
         if let Some(p) = G2Affine::get_point_from_x(x, greatest) {
-            if !p.into_projective().mul(Fr::characteristic()).is_zero() {
+            if !p
+                .into_projective()
+                .mul_bigint(Fr::characteristic())
+                .is_zero()
+            {
                 assert!(!p.is_in_correct_subgroup_assuming_on_curve());
                 return;
             }

--- a/cp6_782/src/curves/mod.rs
+++ b/cp6_782/src/curves/mod.rs
@@ -2,7 +2,7 @@ use ark_ec::{models::short_weierstrass::SWCurveConfig, PairingEngine};
 use ark_ff::{
     biginteger::BigInteger832,
     fields::{BitIteratorBE, Field},
-    BigInt, One,
+    BigInt, CyclotomicMultSubgroup, One,
 };
 
 use crate::{Fq, Fq3, Fq6, Fr};


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR is related to https://github.com/arkworks-rs/r1cs-std/pull/97. It appears that we need to first get the `cargo build` part work, and then `cargo test` can work, as each crate depends on another crate in the testing.

This subsumes all the changes in #109.

closes: #109 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the Github PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`