### PR TITLE
Fix Bandersnatch parameters and the constraint tests

### DIFF
--- a/bls12_377/src/constraints/mod.rs
+++ b/bls12_377/src/constraints/mod.rs
@@ -106,7 +106,7 @@
 //! ```
 //! # fn main() -> Result<(), ark_relations::r1cs::SynthesisError> {
 //! # use ark_std::UniformRand;
-//! # use ark_ec::PairingEngine;
+//! # use ark_ec::pairing::Pairing;
 //! # use ark_relations::r1cs::*;
 //! # use ark_r1cs_std::prelude::*;
 //! # use ark_bls12_377::{*, constraints::*};
@@ -135,7 +135,7 @@
 //! let pairing_result = constraints::PairingVar::pairing(a_prep, b_prep)?;
 //!
 //! // Check that the value of &a + &b is correct.
-//! assert_eq!(pairing_result.value()?, pairing_result_native);
+//! assert_eq!(pairing_result.value()?, pairing_result_native.0);
 //!
 //! // Check that operations on variables and constants are equivalent.
 //! let a_prep_const = constraints::PairingVar::prepare_g1(&a_const)?;

--- a/ed_on_bls12_381_bandersnatch/src/curves/mod.rs
+++ b/ed_on_bls12_381_bandersnatch/src/curves/mod.rs
@@ -17,10 +17,10 @@ pub type SWAffine = short_weierstrass::Affine<BandersnatchParameters>;
 pub type SWProjective = short_weierstrass::Projective<BandersnatchParameters>;
 
 /// `bandersnatch` is an incomplete twisted Edwards curve. These curves have equations of
-/// the form: ax² + y² = 1 - dx²y².
+/// the form: ax² + y² = 1 + dx²y².
 /// over some base finite field Fq.
 ///
-/// bandersnatch's curve equation: -5x² + y² = 1 - dx²y²
+/// bandersnatch's curve equation: -5x² + y² = 1 + dx²y²
 ///
 /// q = 52435875175126190479447740508185965837690552500527637822603658699938581184513.
 ///
@@ -84,7 +84,7 @@ impl TECurveConfig for BandersnatchParameters {
     /// Multiplication by `a` is multiply by `-5`.
     #[inline(always)]
     fn mul_by_a(elem: Self::BaseField) -> Self::BaseField {
-        elem.double().double() * elem
+        -(elem.double().double() + elem)
     }
 }
 

--- a/mnt4_298/src/constraints/mod.rs
+++ b/mnt4_298/src/constraints/mod.rs
@@ -106,7 +106,7 @@
 //! ```
 //! # fn main() -> Result<(), ark_relations::r1cs::SynthesisError> {
 //! # use ark_std::UniformRand;
-//! # use ark_ec::PairingEngine;
+//! # use ark_ec::pairing::Pairing;
 //! # use ark_relations::r1cs::*;
 //! # use ark_r1cs_std::prelude::*;
 //! # use ark_mnt4_298::{*, constraints::*};
@@ -135,7 +135,7 @@
 //! let pairing_result = constraints::PairingVar::pairing(a_prep, b_prep)?;
 //!
 //! // Check that the value of &a + &b is correct.
-//! assert_eq!(pairing_result.value()?, pairing_result_native);
+//! assert_eq!(pairing_result.value()?, pairing_result_native.0);
 //!
 //! // Check that operations on variables and constants are equivalent.
 //! let a_prep_const = constraints::PairingVar::prepare_g1(&a_const)?;

--- a/mnt4_753/src/constraints/mod.rs
+++ b/mnt4_753/src/constraints/mod.rs
@@ -106,7 +106,7 @@
 //! ```
 //! # fn main() -> Result<(), ark_relations::r1cs::SynthesisError> {
 //! # use ark_std::UniformRand;
-//! # use ark_ec::PairingEngine;
+//! # use ark_ec::pairing::Pairing;
 //! # use ark_relations::r1cs::*;
 //! # use ark_r1cs_std::prelude::*;
 //! # use ark_mnt4_753::{*, constraints::*};
@@ -135,7 +135,7 @@
 //! let pairing_result = constraints::PairingVar::pairing(a_prep, b_prep)?;
 //!
 //! // Check that the value of &a + &b is correct.
-//! assert_eq!(pairing_result.value()?, pairing_result_native);
+//! assert_eq!(pairing_result.value()?, pairing_result_native.0);
 //!
 //! // Check that operations on variables and constants are equivalent.
 //! let a_prep_const = constraints::PairingVar::prepare_g1(&a_const)?;

--- a/mnt6_298/src/constraints/mod.rs
+++ b/mnt6_298/src/constraints/mod.rs
@@ -106,7 +106,7 @@
 //! ```
 //! # fn main() -> Result<(), ark_relations::r1cs::SynthesisError> {
 //! # use ark_std::UniformRand;
-//! # use ark_ec::PairingEngine;
+//! # use ark_ec::pairing::Pairing;
 //! # use ark_relations::r1cs::*;
 //! # use ark_r1cs_std::prelude::*;
 //! # use ark_mnt6_298::{*, constraints::*};
@@ -135,7 +135,7 @@
 //! let pairing_result = constraints::PairingVar::pairing(a_prep, b_prep)?;
 //!
 //! // Check that the value of &a + &b is correct.
-//! assert_eq!(pairing_result.value()?, pairing_result_native);
+//! assert_eq!(pairing_result.value()?, pairing_result_native.0);
 //!
 //! // Check that operations on variables and constants are equivalent.
 //! let a_prep_const = constraints::PairingVar::prepare_g1(&a_const)?;

--- a/mnt6_753/src/constraints/mod.rs
+++ b/mnt6_753/src/constraints/mod.rs
@@ -106,7 +106,7 @@
 //! ```
 //! # fn main() -> Result<(), ark_relations::r1cs::SynthesisError> {
 //! # use ark_std::UniformRand;
-//! # use ark_ec::PairingEngine;
+//! # use ark_ec::pairing::Pairing;
 //! # use ark_relations::r1cs::*;
 //! # use ark_r1cs_std::prelude::*;
 //! # use ark_mnt6_753::{*, constraints::*};
@@ -135,7 +135,7 @@
 //! let pairing_result = constraints::PairingVar::pairing(a_prep, b_prep)?;
 //!
 //! // Check that the value of &a + &b is correct.
-//! assert_eq!(pairing_result.value()?, pairing_result_native);
+//! assert_eq!(pairing_result.value()?, pairing_result_native.0);
 //!
 //! // Check that operations on variables and constants are equivalent.
 //! let a_prep_const = constraints::PairingVar::prepare_g1(&a_const)?;


### PR DESCRIPTION
## Description

When testing the constraint systems for the pairing-friendly curves, we discover two issues:
1. the doc tests are failing.
2. the Bandersnatch parameters are wrong, which is due to a mistake.

This PR fixes both.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the Github PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
