### PR TITLE
Fix the location of BitIteratorBE

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,5 @@ ark-ff = { git = "https://github.com/arkworks-rs/algebra" }
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra" }
 ark-algebra-bench-templates = { git = "https://github.com/arkworks-rs/algebra" }
 ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra" }
-
 ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std" }
 ark-std = { git = "https://github.com/arkworks-rs/std" }

--- a/cp6_782/src/curves/mod.rs
+++ b/cp6_782/src/curves/mod.rs
@@ -4,7 +4,7 @@ use ark_ec::{
 };
 use ark_ff::{
     biginteger::BigInteger832,
-    fields::{BitIteratorBE, Field},
+    BitIteratorBE, Field,
     BigInt, CyclotomicMultSubgroup, One,
 };
 use itertools::Itertools;
@@ -27,6 +27,7 @@ pub struct CP6_782;
 
 impl Pairing for CP6_782 {
     type ScalarField = Fr;
+    type BaseField = Fq;
     type G1 = G1Projective;
     type G1Affine = G1Affine;
     type G1Prepared = G1Prepared;

--- a/cp6_782/src/curves/mod.rs
+++ b/cp6_782/src/curves/mod.rs
@@ -3,9 +3,7 @@ use ark_ec::{
     pairing::{MillerLoopOutput, Pairing, PairingOutput},
 };
 use ark_ff::{
-    biginteger::BigInteger832,
-    BitIteratorBE, Field,
-    BigInt, CyclotomicMultSubgroup, One,
+    biginteger::BigInteger832, BigInt, BitIteratorBE, CyclotomicMultSubgroup, Field, One,
 };
 use itertools::Itertools;
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Now `BitIteratorBE` needs to be called from `ark_ff::BitIteratorBE` instead of `ark_ff::fields::BitIteratorBE`.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the Github PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
