### PR TITLE
Add supplementary small group bases for some common fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ debug = true
 [patch.crates-io]
 ark-ff = { git = "https://github.com/arkworks-rs/algebra/", branch = "release-0.4-debug-secp256k1" }
 ark-ec = { git = "https://github.com/arkworks-rs/algebra/", branch = "release-0.4-debug-secp256k1" }
-ark-poly = { git = "https://github.com/arkworks-rs/algebra/", branch = "release-0.4-debug-secp256k1" }
+ark-poly = { git = "https://github.com/arkworks-rs/algebra/", branch = "release-0.4" }
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra/", branch = "release-0.4-debug-secp256k1" }
 ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra/", branch = "release-0.4-debug-secp256k1" }
 ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std/", branch = "release-0.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,8 +64,9 @@ debug-assertions = true
 debug = true
 
 [patch.crates-io]
-ark-ff = { git = "https://github.com/arkworks-rs/algebra/", branch = "release-0.4" }
-ark-ec = { git = "https://github.com/arkworks-rs/algebra/", branch = "release-0.4" }
-ark-poly = { git = "https://github.com/arkworks-rs/algebra/", branch = "release-0.4" }
-ark-serialize = { git = "https://github.com/arkworks-rs/algebra/", branch = "release-0.4" }
+ark-ff = { git = "https://github.com/arkworks-rs/algebra/", branch = "release-0.4-debug-secp256k1" }
+ark-ec = { git = "https://github.com/arkworks-rs/algebra/", branch = "release-0.4-debug-secp256k1" }
+ark-poly = { git = "https://github.com/arkworks-rs/algebra/", branch = "release-0.4-debug-secp256k1" }
+ark-serialize = { git = "https://github.com/arkworks-rs/algebra/", branch = "release-0.4-debug-secp256k1" }
+ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra/", branch = "release-0.4-debug-secp256k1" }
 ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std/", branch = "release-0.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,4 @@ ark-ff = { git = "https://github.com/arkworks-rs/algebra/", branch = "release-0.
 ark-ec = { git = "https://github.com/arkworks-rs/algebra/", branch = "release-0.4" }
 ark-poly = { git = "https://github.com/arkworks-rs/algebra/", branch = "release-0.4" }
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra/", branch = "release-0.4" }
+ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std/", branch = "release-0.4" }

--- a/bls12_381/src/fields/fq.rs
+++ b/bls12_381/src/fields/fq.rs
@@ -3,5 +3,7 @@ use ark_ff::fields::{Fp384, MontBackend, MontConfig};
 #[derive(MontConfig)]
 #[modulus = "4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559787"]
 #[generator = "2"]
+#[small_subgroup_base = "3"]
+#[small_subgroup_power = "2"]
 pub struct FqConfig;
 pub type Fq = Fp384<MontBackend<FqConfig, 6>>;

--- a/bls12_381/src/fields/fr.rs
+++ b/bls12_381/src/fields/fr.rs
@@ -3,5 +3,7 @@ use ark_ff::fields::{Fp256, MontBackend, MontConfig};
 #[derive(MontConfig)]
 #[modulus = "52435875175126190479447740508185965837690552500527637822603658699938581184513"]
 #[generator = "7"]
+#[small_subgroup_base = "3"]
+#[small_subgroup_power = "1"]
 pub struct FrConfig;
 pub type Fr = Fp256<MontBackend<FrConfig, 4>>;

--- a/curve25519/src/fields/fq.rs
+++ b/curve25519/src/fields/fq.rs
@@ -3,5 +3,7 @@ use ark_ff::fields::{Fp256, MontBackend, MontConfig};
 #[derive(MontConfig)]
 #[modulus = "57896044618658097711785492504343953926634992332820282019728792003956564819949"]
 #[generator = "2"]
+#[small_subgroup_base = "3"]
+#[small_subgroup_power = "1"]
 pub struct FqConfig;
 pub type Fq = Fp256<MontBackend<FqConfig, 4>>;

--- a/curve25519/src/fields/fr.rs
+++ b/curve25519/src/fields/fr.rs
@@ -3,5 +3,7 @@ use ark_ff::fields::{Fp256, MontBackend, MontConfig};
 #[derive(MontConfig)]
 #[modulus = "7237005577332262213973186563042994240857116359379907606001950938285454250989"]
 #[generator = "2"]
+#[small_subgroup_base = "3"]
+#[small_subgroup_power = "1"]
 pub struct FrConfig;
 pub type Fr = Fp256<MontBackend<FrConfig, 4>>;

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -17,6 +17,7 @@ ark-ff = { version = "0.4.0-alpha", default-features = false }
 ark-ec = { version = "0.4.0-alpha", default-features = false }
 ark-std = { version = "0.4.0-alpha", default-features = false }
 ark-r1cs-std = { version = "0.4.0-alpha", default-features = false, optional = true }
+ark-curve25519 = { path = "../curve25519" }
 
 [dev-dependencies]
 ark-relations = { version = "0.4.0-alpha", default-features = false }

--- a/ed25519/src/fields/fq.rs
+++ b/ed25519/src/fields/fq.rs
@@ -1,7 +1,1 @@
-use ark_ff::fields::{Fp256, MontBackend, MontConfig};
-
-#[derive(MontConfig)]
-#[modulus = "57896044618658097711785492504343953926634992332820282019728792003956564819949"]
-#[generator = "2"]
-pub struct FqConfig;
-pub type Fq = Fp256<MontBackend<FqConfig, 4>>;
+pub use ark_curve25519::{Fq, FqConfig};

--- a/ed25519/src/fields/fr.rs
+++ b/ed25519/src/fields/fr.rs
@@ -1,7 +1,1 @@
-use ark_ff::fields::{Fp256, MontBackend, MontConfig};
-
-#[derive(MontConfig)]
-#[modulus = "7237005577332262213973186563042994240857116359379907606001950938285454250989"]
-#[generator = "2"]
-pub struct FrConfig;
-pub type Fr = Fp256<MontBackend<FrConfig, 4>>;
+pub use ark_curve25519::{Fr, FrConfig};

--- a/secp256k1/src/fields/fq.rs
+++ b/secp256k1/src/fields/fq.rs
@@ -3,5 +3,7 @@ use ark_ff::fields::{Fp256, MontBackend, MontConfig};
 #[derive(MontConfig)]
 #[modulus = "115792089237316195423570985008687907853269984665640564039457584007908834671663"]
 #[generator = "3"]
+#[small_subgroup_base = "3"]
+#[small_subgroup_power = "1"]
 pub struct FqConfig;
 pub type Fq = Fp256<MontBackend<FqConfig, 4>>;

--- a/secp256k1/src/fields/fr.rs
+++ b/secp256k1/src/fields/fr.rs
@@ -3,5 +3,7 @@ use ark_ff::fields::{Fp256, MontBackend, MontConfig};
 #[derive(MontConfig)]
 #[modulus = "115792089237316195423570985008687907852837564279074904382605163141518161494337"]
 #[generator = "7"]
+#[small_subgroup_base = "3"]
+#[small_subgroup_power = "1"]
 pub struct FrConfig;
 pub type Fr = Fp256<MontBackend<FrConfig, 4>>;

--- a/secp256k1/src/fields/tests.rs
+++ b/secp256k1/src/fields/tests.rs
@@ -1,5 +1,8 @@
+use std::str::FromStr;
 use crate::{Fq, Fr};
 use ark_algebra_test_templates::*;
+use ark_algebra_test_templates::num_bigint::BigUint;
+use ark_ff::{MontFp, PrimeField};
 
 test_field!(fr; Fr; mont_prime_field);
 test_field!(fq; Fq; mont_prime_field);

--- a/secp256k1/src/fields/tests.rs
+++ b/secp256k1/src/fields/tests.rs
@@ -1,8 +1,5 @@
-use std::str::FromStr;
 use crate::{Fq, Fr};
 use ark_algebra_test_templates::*;
-use ark_algebra_test_templates::num_bigint::BigUint;
-use ark_ff::{MontFp, PrimeField};
 
 test_field!(fr; Fr; mont_prime_field);
 test_field!(fq; Fq; mont_prime_field);


### PR DESCRIPTION
## Description

This is related to https://github.com/arkworks-rs/algebra/pull/547.

The idea is that for some TurboPlonk implementations, we use the small base not just when we run out of 2-arity, but we use it when constructing the larger domain (e.g., 6x larger). It is preferred to use 6x (by using a 3) rather than 8x.

This is used in the Noah library as a performance improvement.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the Github PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
