### PR TITLE
Adding `AdditiveGroup` and `PrimeGroup`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,11 +164,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install Rust (${{ matrix.rust }})
+      - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          target: aarch64-unknown-none
+          target: thumbv6m-none-eabi
           override: true
 
       - uses: actions/cache@v2
@@ -183,10 +183,10 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
             command: check
-            args: --examples --workspace --exclude ark-curve-constraint-tests --target aarch64-unknown-none
+            args: --examples --workspace --exclude ark-curve-constraint-tests --target thumbv6m-none-eabi
 
       - name: build
         uses: actions-rs/cargo@v1
         with:
             command: build
-            args: --workspace --exclude ark-curve-constraint-tests --target aarch64-unknown-none
+            args: --workspace --exclude ark-curve-constraint-tests --target thumbv6m-none-eabi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,4 +71,4 @@ ark-ec = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-poly = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra/" }
-ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std/" }
+ark-r1cs-std = { git = "https://github.com/mmaker/ark-r1cs-std/", branch = "feature/additive-groups" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,4 +71,4 @@ ark-ec = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-poly = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra/" }
-ark-r1cs-std = { git = "https://github.com/mmaker/ark-r1cs-std/", branch = "feature/additive-groups" }
+ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std/" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,4 +71,4 @@ ark-ec = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-poly = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra/" }
-ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std/" }
+ark-r1cs-std = { git = "https://github.com/mmaker/ark-r1cs-std/#feature/additive-groups" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,4 +71,4 @@ ark-ec = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-poly = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra/" }
-ark-r1cs-std = { git = "https://github.com/mmaker/ark-r1cs-std/#feature/additive-groups" }
+ark-r1cs-std = { git = "https://github.com/mmaker/ark-r1cs-std/", branch = "feature/additive-groups" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,4 +71,5 @@ ark-ec = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-poly = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra/" }
+ark-algebra-bench-templates = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-r1cs-std = { git = "https://github.com/mmaker/ark-r1cs-std/", branch = "feature/additive-groups" }

--- a/bls12_377/src/curves/g1.rs
+++ b/bls12_377/src/curves/g1.rs
@@ -10,7 +10,7 @@ use ark_ec::{
     },
     CurveConfig,
 };
-use ark_ff::{Field, MontFp, PrimeField, Zero};
+use ark_ff::{AdditiveGroup, Field, MontFp, PrimeField, Zero};
 use ark_std::{ops::Neg, One};
 
 use super::g1_swu_iso::{SwuIsoConfig, ISOGENY_MAP_TO_G1};

--- a/bls12_377/src/curves/g2.rs
+++ b/bls12_377/src/curves/g2.rs
@@ -4,10 +4,10 @@ use ark_ec::{
     hashing::curve_maps::wb::{IsogenyMap, WBConfig},
     models::CurveConfig,
     short_weierstrass::{Affine, Projective, SWCurveConfig},
-    AffineRepr, CurveGroup, AdditiveGroup, PrimeGroup,
+    AffineRepr, CurveGroup, PrimeGroup,
 };
 
-use ark_ff::{Field, MontFp, Zero};
+use ark_ff::{AdditiveGroup, Field, MontFp, Zero};
 use ark_std::ops::Neg;
 
 use crate::*;

--- a/bls12_377/src/curves/g2.rs
+++ b/bls12_377/src/curves/g2.rs
@@ -4,7 +4,7 @@ use ark_ec::{
     hashing::curve_maps::wb::{IsogenyMap, WBConfig},
     models::CurveConfig,
     short_weierstrass::{Affine, Projective, SWCurveConfig},
-    AffineRepr, CurveGroup, Group,
+    AffineRepr, CurveGroup, AdditiveGroup, PrimeGroup,
 };
 
 use ark_ff::{Field, MontFp, Zero};

--- a/bls12_381/benches/bls12_381.rs
+++ b/bls12_381/benches/bls12_381.rs
@@ -1,5 +1,4 @@
 use ark_algebra_bench_templates::*;
-
 use ark_bls12_381::{
     fq::Fq, fq2::Fq2, fr::Fr, Bls12_381, Fq12, G1Projective as G1, G2Projective as G2,
 };

--- a/bls12_381/src/curves/g1.rs
+++ b/bls12_381/src/curves/g1.rs
@@ -4,9 +4,9 @@ use ark_ec::{
     hashing::curve_maps::wb::{IsogenyMap, WBConfig},
     models::CurveConfig,
     short_weierstrass::{Affine, SWCurveConfig},
-    AffineRepr, AdditiveGroup, PrimeGroup,
+    AffineRepr, PrimeGroup,
 };
-use ark_ff::{Field, MontFp, PrimeField, Zero};
+use ark_ff::{AdditiveGroup, MontFp, PrimeField, Zero};
 use ark_serialize::{Compress, SerializationError};
 use ark_std::{ops::Neg, One};
 

--- a/bls12_381/src/curves/g1.rs
+++ b/bls12_381/src/curves/g1.rs
@@ -4,7 +4,7 @@ use ark_ec::{
     hashing::curve_maps::wb::{IsogenyMap, WBConfig},
     models::CurveConfig,
     short_weierstrass::{Affine, SWCurveConfig},
-    AffineRepr, Group,
+    AffineRepr, AdditiveGroup, PrimeGroup,
 };
 use ark_ff::{Field, MontFp, PrimeField, Zero};
 use ark_serialize::{Compress, SerializationError};

--- a/bls12_381/src/curves/g2.rs
+++ b/bls12_381/src/curves/g2.rs
@@ -6,7 +6,7 @@ use ark_ec::{
     hashing::curve_maps::wb::{IsogenyMap, WBConfig},
     models::CurveConfig,
     short_weierstrass::{Affine, Projective, SWCurveConfig},
-    AffineRepr, CurveGroup, Group,
+    AffineRepr, CurveGroup, AdditiveGroup, PrimeGroup,
 };
 use ark_ff::{Field, MontFp, Zero};
 use ark_serialize::{Compress, SerializationError};

--- a/bls12_381/src/curves/g2.rs
+++ b/bls12_381/src/curves/g2.rs
@@ -6,9 +6,9 @@ use ark_ec::{
     hashing::curve_maps::wb::{IsogenyMap, WBConfig},
     models::CurveConfig,
     short_weierstrass::{Affine, Projective, SWCurveConfig},
-    AffineRepr, CurveGroup, AdditiveGroup, PrimeGroup,
+    AffineRepr, CurveGroup, PrimeGroup,
 };
-use ark_ff::{Field, MontFp, Zero};
+use ark_ff::{AdditiveGroup, Field, MontFp, Zero};
 use ark_serialize::{Compress, SerializationError};
 
 use super::{

--- a/bls12_381/src/curves/tests/mod.rs
+++ b/bls12_381/src/curves/tests/mod.rs
@@ -1,5 +1,5 @@
 use ark_algebra_test_templates::*;
-use ark_ec::{AffineRepr, CurveGroup, Group};
+use ark_ec::{AffineRepr, CurveGroup, PrimeGroup};
 use ark_ff::{fields::Field, One, UniformRand, Zero};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Compress, Validate};
 use ark_std::{rand::Rng, test_rng, vec};

--- a/bls12_381/src/fields/tests.rs
+++ b/bls12_381/src/fields/tests.rs
@@ -1,4 +1,5 @@
 use ark_algebra_test_templates::*;
+use ark_ec::AdditiveGroup;
 use ark_ff::{
     biginteger::{BigInt, BigInteger, BigInteger384},
     fields::{FftField, Field, Fp12Config, Fp2Config, Fp6Config, PrimeField},

--- a/bn254/src/curves/g1.rs
+++ b/bn254/src/curves/g1.rs
@@ -2,7 +2,7 @@ use ark_ec::{
     models::{short_weierstrass::SWCurveConfig, CurveConfig},
     short_weierstrass::Affine,
 };
-use ark_ff::{Field, MontFp, Zero};
+use ark_ff::{AdditiveGroup, Field, MontFp, Zero};
 
 use crate::{Fq, Fr};
 

--- a/bn254/src/curves/g2.rs
+++ b/bn254/src/curves/g2.rs
@@ -2,7 +2,7 @@ use ark_ec::{
     models::{short_weierstrass::SWCurveConfig, CurveConfig},
     short_weierstrass::Affine,
 };
-use ark_ff::{Field, MontFp, Zero};
+use ark_ff::{AdditiveGroup, MontFp, Zero};
 
 use crate::{Fq, Fq2, Fr};
 

--- a/bw6_761/src/curves/g1.rs
+++ b/bw6_761/src/curves/g1.rs
@@ -2,7 +2,7 @@ use ark_ec::{
     models::{short_weierstrass::SWCurveConfig, CurveConfig},
     short_weierstrass::{Affine, Projective},
 };
-use ark_ff::{Field, MontFp};
+use ark_ff::{AdditiveGroup, MontFp};
 
 use crate::{Fq, Fr};
 

--- a/bw6_761/src/curves/g2.rs
+++ b/bw6_761/src/curves/g2.rs
@@ -2,7 +2,7 @@ use ark_ec::{
     models::{short_weierstrass::SWCurveConfig, CurveConfig},
     short_weierstrass::{Affine, Projective},
 };
-use ark_ff::{Field, MontFp};
+use ark_ff::{AdditiveGroup, MontFp};
 
 use crate::{Fq, Fr};
 

--- a/bw6_761/src/fields/fq3.rs
+++ b/bw6_761/src/fields/fq3.rs
@@ -1,6 +1,6 @@
 use ark_ff::{
     fields::fp3::{Fp3, Fp3Config},
-    Field, MontFp,
+    AdditiveGroup, Field, MontFp,
 };
 
 use crate::Fq;

--- a/bw6_761/src/fields/fq6.rs
+++ b/bw6_761/src/fields/fq6.rs
@@ -1,6 +1,6 @@
 use ark_ff::{
     fields::fp6_2over3::{Fp6, Fp6Config},
-    Field, MontFp,
+    AdditiveGroup, Field, MontFp,
 };
 
 use crate::{Fq, Fq3, Fq3Config};

--- a/cp6_782/src/curves/g2.rs
+++ b/cp6_782/src/curves/g2.rs
@@ -3,7 +3,7 @@ use ark_ec::{
     short_weierstrass::{Affine, Projective, SWCurveConfig},
     AffineRepr, CurveGroup,
 };
-use ark_ff::{Field, MontFp};
+use ark_ff::{AdditiveGroup, MontFp};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::vec::Vec;
 

--- a/cp6_782/src/curves/mod.rs
+++ b/cp6_782/src/curves/mod.rs
@@ -3,7 +3,8 @@ use ark_ec::{
     pairing::{MillerLoopOutput, Pairing, PairingOutput},
 };
 use ark_ff::{
-    biginteger::BigInteger832, BigInt, BitIteratorBE, CyclotomicMultSubgroup, Field, One,
+    biginteger::BigInteger832, AdditiveGroup, BigInt, BitIteratorBE, CyclotomicMultSubgroup, Field,
+    One,
 };
 use itertools::Itertools;
 

--- a/cp6_782/src/fields/fq3.rs
+++ b/cp6_782/src/fields/fq3.rs
@@ -1,6 +1,6 @@
 use ark_ff::{
     fields::fp3::{Fp3, Fp3Config},
-    Field, MontFp,
+    AdditiveGroup, Field, MontFp,
 };
 
 use crate::Fq;

--- a/cp6_782/src/fields/fq6.rs
+++ b/cp6_782/src/fields/fq6.rs
@@ -1,6 +1,6 @@
 use ark_ff::{
     fields::fp6_2over3::{Fp6, Fp6Config},
-    Field, MontFp,
+    AdditiveGroup, Field, MontFp,
 };
 
 use crate::{Fq, Fq3, Fq3Config};

--- a/curve-constraint-tests/src/lib.rs
+++ b/curve-constraint-tests/src/lib.rs
@@ -225,7 +225,7 @@ pub mod fields {
 pub mod curves {
     use ark_ec::{
         short_weierstrass::Projective as SWProjective, twisted_edwards::Projective as TEProjective,
-        CurveGroup, AdditiveGroup,
+        AdditiveGroup, CurveGroup,
     };
     use ark_ff::{BitIteratorLE, Field, One, PrimeField};
     use ark_relations::r1cs::{ConstraintSystem, SynthesisError};

--- a/curve-constraint-tests/src/lib.rs
+++ b/curve-constraint-tests/src/lib.rs
@@ -225,7 +225,7 @@ pub mod fields {
 pub mod curves {
     use ark_ec::{
         short_weierstrass::Projective as SWProjective, twisted_edwards::Projective as TEProjective,
-        CurveGroup, Group,
+        CurveGroup, AdditiveGroup,
     };
     use ark_ff::{BitIteratorLE, Field, One, PrimeField};
     use ark_relations::r1cs::{ConstraintSystem, SynthesisError};

--- a/ed_on_bls12_381/src/fields/tests.rs
+++ b/ed_on_bls12_381/src/fields/tests.rs
@@ -1,5 +1,6 @@
 use crate::{Fq, Fr};
 use ark_algebra_test_templates::*;
+use ark_ec::AdditiveGroup;
 use ark_ff::{
     biginteger::BigInteger256 as BigInteger,
     fields::{Field, LegendreSymbol::*},

--- a/ed_on_bls12_381_bandersnatch/src/curves/mod.rs
+++ b/ed_on_bls12_381_bandersnatch/src/curves/mod.rs
@@ -3,7 +3,7 @@ use ark_ec::{
     short_weierstrass::{self, SWCurveConfig},
     twisted_edwards::{Affine, MontCurveConfig, Projective, TECurveConfig},
 };
-use ark_ff::{Field, MontFp};
+use ark_ff::{AdditiveGroup, MontFp};
 
 use crate::{Fq, Fr};
 

--- a/ed_on_bls12_381_bandersnatch/src/fields/tests.rs
+++ b/ed_on_bls12_381_bandersnatch/src/fields/tests.rs
@@ -1,5 +1,6 @@
 use crate::{Fq, Fr};
 use ark_algebra_test_templates::*;
+use ark_ec::AdditiveGroup;
 use ark_ff::{
     biginteger::BigInteger256 as BigInteger,
     fields::{Field, LegendreSymbol::*},

--- a/ed_on_bn254/src/fields/tests.rs
+++ b/ed_on_bn254/src/fields/tests.rs
@@ -1,4 +1,5 @@
 use ark_algebra_test_templates::*;
+use ark_ec::AdditiveGroup;
 use ark_ff::{
     biginteger::BigInteger256 as BigInteger,
     fields::{Field, LegendreSymbol::*},

--- a/mnt4_298/src/curves/g2.rs
+++ b/mnt4_298/src/curves/g2.rs
@@ -3,7 +3,7 @@ use ark_ec::{
     mnt4::MNT4Config,
     models::{short_weierstrass::SWCurveConfig, CurveConfig},
 };
-use ark_ff::{Field, MontFp};
+use ark_ff::{AdditiveGroup, MontFp};
 
 use crate::{Fq, Fq2, Fr, G1_COEFF_A_NON_RESIDUE};
 

--- a/mnt4_298/src/curves/mod.rs
+++ b/mnt4_298/src/curves/mod.rs
@@ -1,5 +1,5 @@
 use ark_ec::models::mnt4::{MNT4Config, MNT4};
-use ark_ff::{biginteger::BigInteger320, BigInt, Field, MontFp};
+use ark_ff::{biginteger::BigInteger320, AdditiveGroup, BigInt, Field, MontFp};
 
 use crate::{Fq, Fq2, Fq2Config, Fq4Config, Fr};
 

--- a/mnt4_298/src/fields/fq4.rs
+++ b/mnt4_298/src/fields/fq4.rs
@@ -1,6 +1,6 @@
 use ark_ff::{
     fields::fp4::{Fp4, Fp4Config},
-    Field, MontFp,
+    AdditiveGroup, Field, MontFp,
 };
 
 use crate::{Fq, Fq2, Fq2Config};

--- a/mnt4_753/src/curves/g2.rs
+++ b/mnt4_753/src/curves/g2.rs
@@ -3,7 +3,7 @@ use ark_ec::{
     mnt4::MNT4Config,
     models::{short_weierstrass::SWCurveConfig, CurveConfig},
 };
-use ark_ff::{Field, MontFp};
+use ark_ff::{AdditiveGroup, MontFp};
 
 use crate::{Fq, Fq2, Fr, G1_COEFF_A_NON_RESIDUE};
 

--- a/mnt4_753/src/curves/mod.rs
+++ b/mnt4_753/src/curves/mod.rs
@@ -1,7 +1,7 @@
 use ark_ec::models::mnt4::{MNT4Config, MNT4};
 use ark_ff::{
     biginteger::{BigInt, BigInteger768},
-    Field, Fp2, MontFp,
+    AdditiveGroup, Field, Fp2, MontFp,
 };
 
 use crate::{Fq, Fq2Config, Fq4Config, Fr};

--- a/mnt4_753/src/fields/fq4.rs
+++ b/mnt4_753/src/fields/fq4.rs
@@ -1,6 +1,6 @@
 use ark_ff::{
     fields::fp4::{Fp4, Fp4Config},
-    Field, MontFp,
+    AdditiveGroup, Field, MontFp,
 };
 
 use crate::{Fq, Fq2, Fq2Config};

--- a/mnt6_298/src/curves/g2.rs
+++ b/mnt6_298/src/curves/g2.rs
@@ -3,7 +3,7 @@ use ark_ec::{
     mnt6::MNT6Config,
     models::{short_weierstrass::SWCurveConfig, CurveConfig},
 };
-use ark_ff::{Field, MontFp};
+use ark_ff::{AdditiveGroup, MontFp};
 
 use crate::{g1, Fq, Fq3, Fr};
 

--- a/mnt6_298/src/curves/mod.rs
+++ b/mnt6_298/src/curves/mod.rs
@@ -2,7 +2,7 @@ use ark_ec::{
     models::mnt6::{MNT6Config, MNT6},
     short_weierstrass::SWCurveConfig,
 };
-use ark_ff::{biginteger::BigInteger320, BigInt, Field, Fp3};
+use ark_ff::{biginteger::BigInteger320, AdditiveGroup, BigInt, Field, Fp3};
 
 use crate::{Fq, Fq3Config, Fq6Config, Fr};
 

--- a/mnt6_298/src/fields/fq3.rs
+++ b/mnt6_298/src/fields/fq3.rs
@@ -1,6 +1,6 @@
 use ark_ff::{
     fields::fp3::{Fp3, Fp3Config},
-    Field, MontFp,
+    AdditiveGroup, Field, MontFp,
 };
 
 use crate::fq::Fq;

--- a/mnt6_298/src/fields/fq6.rs
+++ b/mnt6_298/src/fields/fq6.rs
@@ -1,6 +1,6 @@
 use ark_ff::{
     fields::fp6_2over3::{Fp6, Fp6Config},
-    Field, MontFp,
+    AdditiveGroup, Field, MontFp,
 };
 
 use crate::{Fq, Fq3, Fq3Config};

--- a/mnt6_753/src/curves/g2.rs
+++ b/mnt6_753/src/curves/g2.rs
@@ -3,7 +3,7 @@ use ark_ec::{
     mnt6::MNT6Config,
     models::{short_weierstrass::SWCurveConfig, CurveConfig},
 };
-use ark_ff::{Field, MontFp};
+use ark_ff::{AdditiveGroup, MontFp};
 
 use crate::{g1, Fq, Fq3, Fr};
 

--- a/mnt6_753/src/curves/mod.rs
+++ b/mnt6_753/src/curves/mod.rs
@@ -2,7 +2,7 @@ use ark_ec::models::{
     mnt6::{MNT6Config, MNT6},
     short_weierstrass::SWCurveConfig,
 };
-use ark_ff::{biginteger::BigInteger768, BigInt, Field, Fp3};
+use ark_ff::{biginteger::BigInteger768, AdditiveGroup, BigInt, Field, Fp3};
 
 use crate::{Fq, Fq3Config, Fq6Config, Fr};
 

--- a/mnt6_753/src/fields/fq3.rs
+++ b/mnt6_753/src/fields/fq3.rs
@@ -1,6 +1,6 @@
 use ark_ff::{
     fields::fp3::{Fp3, Fp3Config},
-    Field, MontFp,
+    AdditiveGroup, Field, MontFp,
 };
 
 use crate::fq::Fq;

--- a/mnt6_753/src/fields/fq6.rs
+++ b/mnt6_753/src/fields/fq6.rs
@@ -1,6 +1,6 @@
 use ark_ff::{
     fields::fp6_2over3::{Fp6, Fp6Config},
-    Field, MontFp,
+    AdditiveGroup, Field, MontFp,
 };
 
 use crate::{Fq, Fq3, Fq3Config};

--- a/pallas/src/curves/mod.rs
+++ b/pallas/src/curves/mod.rs
@@ -2,7 +2,7 @@ use ark_ec::{
     models::CurveConfig,
     short_weierstrass::{self as sw, SWCurveConfig},
 };
-use ark_ff::{Field, MontFp, Zero};
+use ark_ff::{AdditiveGroup, Field, MontFp, Zero};
 
 use crate::{fq::Fq, fr::Fr};
 

--- a/secp256k1/src/curves/mod.rs
+++ b/secp256k1/src/curves/mod.rs
@@ -2,7 +2,7 @@ use ark_ec::{
     models::CurveConfig,
     short_weierstrass::{self as sw, SWCurveConfig},
 };
-use ark_ff::{Field, MontFp, Zero};
+use ark_ff::{AdditiveGroup, Field, MontFp, Zero};
 
 use crate::{fq::Fq, fr::Fr};
 

--- a/secq256k1/src/curves/mod.rs
+++ b/secq256k1/src/curves/mod.rs
@@ -2,7 +2,7 @@ use ark_ec::{
     models::CurveConfig,
     short_weierstrass::{self as sw, SWCurveConfig},
 };
-use ark_ff::{Field, MontFp, Zero};
+use ark_ff::{AdditiveGroup, Field, MontFp, Zero};
 
 use crate::{fq::Fq, fr::Fr};
 

--- a/vesta/src/curves/mod.rs
+++ b/vesta/src/curves/mod.rs
@@ -3,7 +3,7 @@ use ark_ec::{
     models::CurveConfig,
     short_weierstrass::{self as sw, SWCurveConfig},
 };
-use ark_ff::{Field, MontFp, Zero};
+use ark_ff::{AdditiveGroup, Field, MontFp, Zero};
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
See arkworks-rs/algebra#577.

I changed `Cargo.toml` to avoid redoing what arkworks-rs/r1cs-std#122 has done.

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
