### PR TITLE
Follow ark-algebra's no_std CI 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          target: aarch64-unknown-none
+          target: thumbv6m-none-eabi
           override: true
 
       - uses: actions/cache@v2
@@ -183,10 +183,10 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
             command: check
-            args: --examples --workspace --exclude ark-curve-constraint-tests --target aarch64-unknown-none
+            args: --examples --workspace --exclude ark-curve-constraint-tests --target thumbv6m-none-eabi
 
       - name: build
         uses: actions-rs/cargo@v1
         with:
             command: build
-            args: --workspace --exclude ark-curve-constraint-tests --target aarch64-unknown-none
+            args: --workspace --exclude ark-curve-constraint-tests --target thumbv6m-none-eabi


### PR DESCRIPTION
## Description

As a temporary rescue, we change the GitHub CI to be using the same no_std CI as in ark-algebra.

This is to unblock a number of PRs. It seems that the ark-algebra CI does not detect no_std problems regarding aarch64-unknown-none. We might be able to travel back in time to see where this issue arises (and what changes in Rust cause it). 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the Github PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
