### PR TITLE
Revert "temp switch to bw6-optimization branch on algebra"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,10 +68,10 @@ debug-assertions = true
 debug = true
 
 [patch.crates-io]
-ark-ff = { git = "https://github.com/arkworks-rs/algebra/", branch = "bw6-optimization" }
-ark-ec = { git = "https://github.com/arkworks-rs/algebra/", branch = "bw6-optimization" }
-ark-poly = { git = "https://github.com/arkworks-rs/algebra/", branch = "bw6-optimization" }
-ark-serialize = { git = "https://github.com/arkworks-rs/algebra/", branch = "bw6-optimization" }
-ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra/", branch = "bw6-optimization" }
-ark-algebra-bench-templates = { git = "https://github.com/arkworks-rs/algebra/", branch = "bw6-optimization" }
+ark-ff = { git = "https://github.com/arkworks-rs/algebra/" }
+ark-ec = { git = "https://github.com/arkworks-rs/algebra/" }
+ark-poly = { git = "https://github.com/arkworks-rs/algebra/" }
+ark-serialize = { git = "https://github.com/arkworks-rs/algebra/" }
+ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra/" }
+ark-algebra-bench-templates = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std/" }


### PR DESCRIPTION
This reverts commit fc85b0ac2a988a784b6116058b8cb1d30cbf4cd1.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

To be merged after https://github.com/arkworks-rs/algebra/pull/617

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
