### PR TITLE
chore(bls12_377): typo fix

### DIFF
--- a/bls12_377/scripts/bls12_isogeny_computer.sage
+++ b/bls12_377/scripts/bls12_isogeny_computer.sage
@@ -197,7 +197,7 @@ def bls12_377_hash_to_G2(e2_p6S_iso, data):
 # e26_order = Ell2_6.order()
 # for i in primes(30):
 #     if e26_order % i == 0:
-#         print("order is divisable by ", i)
+#         print("order is divisible by ", i)
 
 def find_non_square():
     quad_non_res = 0x01ae3a4617c510eac63b05c06ca1493b1a22d9f300f5138f1ef3622fba094800170b5d44300000008508bffffffffffc

--- a/bls12_381/src/curves/g2.rs
+++ b/bls12_381/src/curves/g2.rs
@@ -295,7 +295,7 @@ fn double_p_power_endomorphism(p: &Projective<Config>) -> Projective<Config> {
     res
 }
 
-// Parametres from the [IETF draft v16, section E.3](https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-16.html#name-3-isogeny-map-for-bls12-381).
+// Parameters from the [IETF draft v16, section E.3](https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-16.html#name-3-isogeny-map-for-bls12-381).
 impl WBConfig for Config {
     type IsogenousCurve = g2_swu_iso::SwuIsoConfig;
 

--- a/bls12_381/src/curves/util.rs
+++ b/bls12_381/src/curves/util.rs
@@ -121,7 +121,7 @@ pub(crate) fn read_g1_compressed<R: ark_serialize::Read>(
     let x_bytes = read_bytes_with_offset(&bytes, 0, true);
 
     if flags.is_infinity {
-        // Check that the `x` co-ordinate was `0`
+        // Checks that the `x` coordinate was `0`
         if x_bytes != [0u8; 48] {
             return Err(SerializationError::InvalidData);
         }


### PR DESCRIPTION


Hello I am learning web3 programming, I went through some of the code because I was told zk technology is fascinating (and it is). I found some little errors in comments, nothing important, except one of them that is printed to the user. I checked all files so the repo should now be typo free! I hope you don't mind opening a PR for such a little thing, I read the contributing file and didn't find it being forbidden, but even if it is little I hope i'll help you even just a bit in your research. Thank you for making that repo public. Have a nice day.
