### PR TITLE
feat: Add support for constraint usage within ark_bn254

### DIFF
--- a/bn254/Cargo.toml
+++ b/bn254/Cargo.toml
@@ -16,16 +16,18 @@ edition = "2021"
 ark-ff = { version= "0.4.0", default-features = false }
 ark-ec = { version= "0.4.0", default-features = false }
 ark-std = { version = "0.4.0", default-features = false }
+ark-r1cs-std = { version = "0.4.0", default-features = false, optional = true }
 
 [dev-dependencies]
 ark-serialize = { version = "0.4.0", default-features = false }
 ark-algebra-test-templates = { version = "0.4.0", default-features = false }
 ark-algebra-bench-templates = { version = "0.4.0", default-features = false }
+ark-curve-constraint-tests = { path = "../curve-constraint-tests", default-features = false }
 
 [features]
 default = [ "curve" ]
 std = [ "ark-std/std", "ark-ff/std", "ark-ec/std" ]
-
+r1cs = [ "ark-r1cs-std" ]
 curve = [ "scalar_field" ]
 scalar_field = []
 

--- a/bn254/Cargo.toml
+++ b/bn254/Cargo.toml
@@ -23,6 +23,7 @@ ark-serialize = { version = "0.4.0", default-features = false }
 ark-algebra-test-templates = { version = "0.4.0", default-features = false }
 ark-algebra-bench-templates = { version = "0.4.0", default-features = false }
 ark-curve-constraint-tests = { path = "../curve-constraint-tests", default-features = false }
+ark-relations = { version = "0.4.0", default-features = false }
 
 [features]
 default = [ "curve" ]

--- a/bn254/src/constraints/curves.rs
+++ b/bn254/src/constraints/curves.rs
@@ -1,0 +1,11 @@
+use ark_r1cs_std::groups::curves::short_weierstrass::ProjectiveVar;
+
+use crate::{constraints::FBaseVar, g1::Config};
+
+/// A group element in the Grumpkin prime-order group.
+pub type GVar = ProjectiveVar<Config, FBaseVar>;
+
+#[test]
+fn test() {
+    ark_curve_constraint_tests::curves::sw_test::<Config, GVar>().unwrap();
+}

--- a/bn254/src/constraints/curves.rs
+++ b/bn254/src/constraints/curves.rs
@@ -2,7 +2,7 @@ use ark_r1cs_std::groups::curves::short_weierstrass::ProjectiveVar;
 
 use crate::{constraints::FBaseVar, g1::Config};
 
-/// A group element in the Grumpkin prime-order group.
+/// A group element in the Bn254 prime-order group.
 pub type GVar = ProjectiveVar<Config, FBaseVar>;
 
 #[test]

--- a/bn254/src/constraints/fields.rs
+++ b/bn254/src/constraints/fields.rs
@@ -1,0 +1,11 @@
+use ark_r1cs_std::fields::fp::FpVar;
+
+use crate::fq::Fq;
+
+/// A variable that is the R1CS equivalent of `crate::Fq`.
+pub type FBaseVar = FpVar<Fq>;
+
+#[test]
+fn test() {
+    ark_curve_constraint_tests::fields::field_test::<_, _, FBaseVar>().unwrap();
+}

--- a/bn254/src/constraints/mod.rs
+++ b/bn254/src/constraints/mod.rs
@@ -1,0 +1,107 @@
+//! This module implements the R1CS equivalent of `ark_bn254`.
+//!
+//! It implements field variables for `crate::Fq`,
+//! and group variables for `crate::Projective`.
+//!
+//! The field underlying these constraints is `crate::Fq`.
+//!
+//! # Examples
+//!
+//! One can perform standard algebraic operations on `FBaseVar`:
+//!
+//! ```
+//! # fn main() -> Result<(), ark_relations::r1cs::SynthesisError> {
+//! use ark_std::UniformRand;
+//! use ark_relations::r1cs::*;
+//! use ark_r1cs_std::prelude::*;
+//! use ark_bn254::{*, constraints::*};
+//!
+//! let cs = ConstraintSystem::<Fq>::new_ref();
+//! // This rng is just for test purposes; do not use it
+//! // in real applications.
+//! let mut rng = ark_std::test_rng();
+//!
+//! // Generate some random `Fq` elements.
+//! let a_native = Fq::rand(&mut rng);
+//! let b_native = Fq::rand(&mut rng);
+//!
+//! // Allocate `a_native` and `b_native` as witness variables in `cs`.
+//! let a = FBaseVar::new_witness(ark_relations::ns!(cs, "generate_a"), || Ok(a_native))?;
+//! let b = FBaseVar::new_witness(ark_relations::ns!(cs, "generate_b"), || Ok(b_native))?;
+//!
+//! // Allocate `a_native` and `b_native` as constants in `cs`. This does not add any
+//! // constraints or variables.
+//! let a_const = FBaseVar::new_constant(ark_relations::ns!(cs, "a_as_constant"), a_native)?;
+//! let b_const = FBaseVar::new_constant(ark_relations::ns!(cs, "b_as_constant"), b_native)?;
+//!
+//! let one = FBaseVar::one();
+//! let zero = FBaseVar::zero();
+//!
+//! // Sanity check one + one = two
+//! let two = &one + &one + &zero;
+//! two.enforce_equal(&one.double()?)?;
+//!
+//! assert!(cs.is_satisfied()?);
+//!
+//! // Check that the value of &a + &b is correct.
+//! assert_eq!((&a + &b).value()?, a_native + &b_native);
+//!
+//! // Check that the value of &a * &b is correct.
+//! assert_eq!((&a * &b).value()?, a_native * &b_native);
+//!
+//! // Check that operations on variables and constants are equivalent.
+//! (&a + &b).enforce_equal(&(&a_const + &b_const))?;
+//! assert!(cs.is_satisfied()?);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! One can also perform standard algebraic operations on `GVar`:
+//!
+//! ```
+//! # fn main() -> Result<(), ark_relations::r1cs::SynthesisError> {
+//! # use ark_std::UniformRand;
+//! # use ark_relations::r1cs::*;
+//! # use ark_r1cs_std::prelude::*;
+//! # use ark_bn254::{*, constraints::*};
+//!
+//! # let cs = ConstraintSystem::<Fq>::new_ref();
+//! # let mut rng = ark_std::test_rng();
+//!
+//! // Generate some random `Projective` elements.
+//! let a_native = Projective::rand(&mut rng);
+//! let b_native = Projective::rand(&mut rng);
+//!
+//! // Allocate `a_native` and `b_native` as witness variables in `cs`.
+//! let a = GVar::new_witness(ark_relations::ns!(cs, "a"), || Ok(a_native))?;
+//! let b = GVar::new_witness(ark_relations::ns!(cs, "b"), || Ok(b_native))?;
+//!
+//! // Allocate `a_native` and `b_native` as constants in `cs`. This does not add any
+//! // constraints or variables.
+//! let a_const = GVar::new_constant(ark_relations::ns!(cs, "a_as_constant"), a_native)?;
+//! let b_const = GVar::new_constant(ark_relations::ns!(cs, "b_as_constant"), b_native)?;
+//!
+//! // This returns the identity.
+//! let zero = GVar::zero();
+//!
+//! // Sanity check one + one = two
+//! let two_a = &a + &a + &zero;
+//! two_a.enforce_equal(&a.double()?)?;
+//!
+//! assert!(cs.is_satisfied()?);
+//!
+//! // Check that the value of &a + &b is correct.
+//! assert_eq!((&a + &b).value()?, a_native + &b_native);
+//!
+//! // Check that operations on variables and constants are equivalent.
+//! (&a + &b).enforce_equal(&(&a_const + &b_const))?;
+//! assert!(cs.is_satisfied()?);
+//! # Ok(())
+//! # }
+//! ```
+
+mod curves;
+mod fields;
+
+pub use curves::*;
+pub use fields::*;

--- a/bn254/src/constraints/mod.rs
+++ b/bn254/src/constraints/mod.rs
@@ -1,7 +1,7 @@
 //! This module implements the R1CS equivalent of `ark_bn254`.
 //!
 //! It implements field variables for `crate::Fq`,
-//! and group variables for `crate::Projective`.
+//! and group variables for `crate::G1Projective`.
 //!
 //! The field underlying these constraints is `crate::Fq`.
 //!
@@ -68,9 +68,9 @@
 //! # let cs = ConstraintSystem::<Fq>::new_ref();
 //! # let mut rng = ark_std::test_rng();
 //!
-//! // Generate some random `Projective` elements.
-//! let a_native = Projective::rand(&mut rng);
-//! let b_native = Projective::rand(&mut rng);
+//! // Generate some random `G1Projective` elements.
+//! let a_native = G1Projective::rand(&mut rng);
+//! let b_native = G1Projective::rand(&mut rng);
 //!
 //! // Allocate `a_native` and `b_native` as witness variables in `cs`.
 //! let a = GVar::new_witness(ark_relations::ns!(cs, "a"), || Ok(a_native))?;

--- a/bn254/src/lib.rs
+++ b/bn254/src/lib.rs
@@ -41,3 +41,6 @@ mod fields;
 pub use curves::*;
 
 pub use fields::*;
+
+#[cfg(feature = "r1cs")]
+pub mod constraints;


### PR DESCRIPTION
## Description

This modifies the `Cargo.toml` with the following changes:
- Add `ark-r1cs-std` as an optional dependency.
- Add `ark-curve-constraint-tests` an a dev-dependency.
- Add `r1cs` feature which activates `ark-r1cs-std` depencendy.

It also adds all the necessary module files witin the `constraints` folder to make it work in 8cb2eaef2af575f9cf46e322a880fc3f12ae56cf


closes: #186 

cc: @arnaucube